### PR TITLE
Fix marketplace JSON validation warnings

### DIFF
--- a/umbraco-marketplace.json
+++ b/umbraco-marketplace.json
@@ -22,19 +22,11 @@
   "DocumentationUrl": "https://umtemplates.github.io/UpDoc/",
   "IssueTrackerUrl": "https://github.com/UmTemplates/UpDoc/issues",
   "DiscussionForumUrl": "",
-  "VideoUrl": "",
   "Tags": ["pdf", "content-import", "extraction", "workflow", "mapping", "blueprint"],
   "Screenshots": [],
   "PackagesByAuthor": [
     "Umbraco.Community.Templates.UmBootstrap"
   ],
   "RelatedPackages": [],
-  "AddOnPackagesRequiredForUmbracoCloud": [],
-  "VersionSpecificPackageIds": [
-    {
-      "UmbracoMajorVersion": 17,
-      "PackageId": "Umbraco.Community.UpDoc"
-    }
-  ],
-  "VersionDependencyMode": "Default"
+  "AddOnPackagesRequiredForUmbracoCloud": []
 }


### PR DESCRIPTION
## Summary

Fixes two warnings from the Umbraco Marketplace validator:

- Remove empty `VideoUrl` — must be an absolute URL or omitted entirely
- Remove `VersionSpecificPackageIds` — package can't map to itself

No NuGet release needed — the marketplace reads this file from GitHub.

## Test plan

- [ ] Re-run marketplace JSON validator — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)