### PR TITLE
Add 'Updating Blueprints' docs page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,14 @@ These files contain agreed-upon design decisions, config schemas, and implementa
 
 ---
 
+## GitHub Issues
+
+This project tracks work in GitHub Issues (visible in the GitHub Pull Requests and Issues VS Code extension sidebar). Before starting any non-trivial task — feature, bug fix, meaningful docs change, new planning doc — check `gh issue list` for an existing issue. If none exists, ask whether one should be created before proceeding. Reference the issue number in commits (`Closes #12`) and PR bodies so the board stays in sync with the work.
+
+Issues are not required for trivial changes (typo fixes, one-line corrections) — use judgement. If in doubt, ask.
+
+---
+
 ## Project Structure
 
 This project is a two-project solution:

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -19,6 +19,7 @@ export default defineConfig({
 				{ label: 'Introduction', slug: 'introduction' },
 				{ label: 'Setting Up a Workflow', slug: 'setup' },
 				{ label: 'Creating Documents from Source', slug: 'usage' },
+				{ label: 'Updating Blueprints', slug: 'updating-blueprints' },
 				{ label: 'User Journeys', slug: 'user-journeys' },
 				{ label: 'Mapping Directions', slug: 'mapping-directions' },
 				{

--- a/docs/src/content/docs/updating-blueprints.md
+++ b/docs/src/content/docs/updating-blueprints.md
@@ -1,0 +1,139 @@
+---
+title: "Updating Blueprints"
+---
+
+This guide is for workflow authors. It explains what happens to your workflow mappings when the underlying document blueprint changes — and what to do after making changes.
+
+Blueprints evolve over time. You might add a new feature block, tweak default content, or even remake the blueprint from scratch because some block types can only be created on a published page (synchronised navigation blocks, for example). Understanding how UpDoc reconciles these changes helps you avoid surprises.
+
+---
+
+## The short answer
+
+Most blueprint changes are safe. UpDoc identifies blocks by their **type** (content type key), not by their instance GUID. Remaking a blueprint with the same blocks preserves your mappings — even though every block instance has a new GUID under the hood.
+
+There is one edge case to watch: **two or more blocks of the same type in one blueprint**. If your blueprint has that, read the "Duplicate block types" section below.
+
+---
+
+## How UpDoc identifies blocks
+
+Every block in an Umbraco blueprint has two identifiers:
+
+| Identifier | Stable? | Description |
+|------------|---------|-------------|
+| `contentTypeKey` | ✅ Yes | The element type GUID — e.g. "Feature Rich Text Itinerary" |
+| Instance `key` | ❌ No | Unique per block instance; regenerated when the blueprint is remade |
+
+UpDoc's mappings store both, but reconciliation uses `contentTypeKey` to find the equivalent block in a new version of the blueprint. Instance GUIDs are re-learned each time.
+
+This is the same reason that Umbraco itself regenerates instance GUIDs when creating a document from a blueprint: the block *types* are what matters structurally, not the specific instances.
+
+---
+
+## What's safe to change
+
+### ✅ Changing the source
+
+You can freely change the source side of a workflow:
+
+- Pick a different PDF or markdown file
+- Change a web source URL
+- Re-extract from the same source with different rules
+
+None of this affects mappings. Mappings reference sources by stable section keys, not by the source document itself.
+
+### ✅ Editing blueprint content
+
+Changes to the blueprint that don't add or remove blocks are safe:
+
+- Editing default property values
+- Changing labels or descriptions on properties
+- Reordering blocks within the same block grid (mappings survive — `contentTypeKey` still matches)
+
+After any of these, you don't strictly need to regenerate the destination — but doing so picks up any changes to the filtered destination structure.
+
+### ✅ Remaking a blueprint with the same blocks
+
+This is the common "can't edit this block type, have to rebuild" scenario.
+
+1. Create a new blueprint with the same blocks
+2. In the workflow, point at the new blueprint (or if it has the same name, UpDoc picks it up)
+3. Click **regenerate destination** on the workflow
+4. UpDoc walks each mapping, finds the equivalent block by `contentTypeKey` in the new destination, and rewrites the instance GUID
+5. Mappings survive
+
+You'll see a confirmation like "Reconciled N blockKeys, 0 orphaned". As long as orphaned is zero, everything is wired correctly.
+
+---
+
+## What needs attention
+
+### ⚠️ Adding a new block type
+
+If you add a block to the blueprint that wasn't there before:
+
+- Existing mappings keep working — the new block is simply unmapped
+- The new block appears in the destination structure after regenerate-destination
+- You can then map source content to it
+
+### ⚠️ Removing a block from the blueprint
+
+If you remove a block:
+
+- Mappings that targeted that block are marked **orphaned** on the Map tab
+- The document is still created successfully — the orphaned mappings are silently skipped
+- Review orphaned entries and either delete them or re-map them to a different block
+
+### ⚠️ Duplicate block types
+
+This is the only tricky case. If your blueprint contains two or more blocks of the **same** `contentTypeKey` — for example, two "Feature Rich Text" blocks used for Introduction and Itinerary — reconciliation after a blueprint remake is ambiguous.
+
+UpDoc can match the type, but can't distinguish which instance in the new blueprint was the "Introduction" one versus the "Itinerary" one. After regenerate-destination, all mappings to that block type may collapse onto a single instance.
+
+**What to do:**
+
+1. Check the Map tab after reconciliation
+2. If multiple mappings point at the same block, reassign one of them to the correct instance using the destination picker
+3. Most projects never hit this — using distinct block types per purpose sidesteps the issue entirely
+
+---
+
+## Workflow: updating a blueprint safely
+
+1. **Make your blueprint changes** (edit, or remake as a new blueprint with the same name)
+2. **Open the workflow** in Settings → UpDoc → Workflows
+3. **Click "Regenerate destination"** — this re-reads the blueprint and reconciles blockKeys
+4. **Read the result** — look for the "N reconciled, M orphaned" summary
+5. **Check the Map tab** — any mapping tagged "Orphaned" needs attention
+6. **Test** by creating a document from source and verifying the content lands in the right places
+
+---
+
+## Why blueprints at all?
+
+UpDoc is a content *populator*, not a content *builder*. The blueprint defines the structural skeleton — which blocks exist, in what order, with what default settings — and UpDoc fills that skeleton with source content.
+
+This design keeps UpDoc focused on the hard problem (extraction and mapping) rather than rebuilding the block composition UI. It's a trade-off: you can't create blocks that aren't in the blueprint, but the mapping flow stays simple and the blueprint remains the single source of truth for structure.
+
+A "create blocks if missing" mode has been considered but would be a substantial architectural change. For now, every block you want populated needs to exist in the blueprint.
+
+---
+
+## Troubleshooting
+
+**"All my mappings are orphaned after remaking the blueprint"**
+
+Check that the new blueprint uses the same element types (same `contentTypeKey`s) as the old one. If you created new element types with the same names, they have different GUIDs and UpDoc can't match them. Solution: delete the new element types and use the originals.
+
+**"Only some mappings reconciled"**
+
+The unreconciled ones are mappings whose block type no longer exists in the new blueprint. Review them on the Map tab and either remove them or map them to a different target.
+
+**"My mapping points at the wrong block instance"**
+
+You probably have duplicate block types. See the "Duplicate block types" section above.
+
+**"The new blueprint isn't showing up"**
+
+UpDoc reads blueprints via the document type. Make sure the new blueprint is based on the same document type as the workflow expects. Check `workflow.json` in the workflow folder if you need to confirm.

--- a/planning/DOCS_SCREENSHOT_AUTOMATION.md
+++ b/planning/DOCS_SCREENSHOT_AUTOMATION.md
@@ -1,0 +1,221 @@
+# Docs Screenshot Automation — Planning Note
+
+**Status:** Deferred — idea captured for future sessions.
+
+**Context:** The UpDoc docs (Astro Starlight) are text-heavy. A tool this visual deserves screenshots of the UI flows it describes. Manually taking and maintaining screenshots is high-effort and rots fast — every UI tweak invalidates captures across the site.
+
+**Proposal:** Use the existing Playwright setup to drive the backoffice through documented flows and capture screenshots at predetermined steps. Regenerate screenshots by running the spec after UI changes.
+
+---
+
+## Why this fits
+
+- Authentication is already solved (`tests/e2e/auth.setup.ts`, Playwright API user, `.env` credentials)
+- Known test content exists (Winchester PDFs, Group Tours tree, blueprint GUIDs are stable)
+- Playwright's `page.screenshot({ path, clip, mask })` handles targeted captures
+- One command rebuilds all docs imagery → screenshots stay in sync with reality
+- The same infrastructure can capture `.webm` video for flow-based GIFs (drag-drop, modal flows)
+
+---
+
+## Scope for a first pass
+
+Pick **one docs page** — suggest `usage.md` (content editor flow) — and build the pipeline end to end before generalising. Success criteria: running a single command regenerates every screenshot on that page from a clean backoffice state.
+
+Once that works, replicate for:
+1. `usage.md` — content editor flow
+2. `user-journeys.md` — end-to-end scenarios
+3. `setup.md` — workflow author first run
+4. `mapping-directions.md` — three-tab model visuals
+5. `ui` section — component overview
+
+---
+
+## Proposed structure
+
+```
+src/UpDoc/wwwroot/App_Plugins/UpDoc/tests/
+  e2e/                           # existing E2E tests
+  docs-screenshots/              # NEW — separate folder, separate purpose
+    usage.screenshots.ts
+    user-journeys.screenshots.ts
+    setup.screenshots.ts
+    helpers/
+      viewport.ts                # fixed viewport (1440×900) for consistency
+      capture.ts                 # wrapper around page.screenshot with defaults
+      cleanup.ts                 # remove test documents after capture
+
+docs/src/assets/screenshots/
+  usage/
+    01-context-menu.png
+    02-blueprint-picker.png
+    03-source-sidebar.png
+    ...
+  user-journeys/
+    ...
+```
+
+**Separation from E2E tests**: different purpose (artefact generation vs correctness check), different run cadence (on-demand vs CI), different failure tolerance (screenshots can fail silently; tests must not).
+
+---
+
+## Key decisions to make before implementing
+
+### Viewport
+
+Fix viewport size (e.g. 1440×900). Variable sizes produce visual drift between captures and make it harder to spot real changes.
+
+### Theme
+
+Pick light or dark and stick with it across all docs. Mixing produces jarring visual inconsistency. Suggest light (matches Umbraco default).
+
+### Annotations
+
+Playwright can't draw arrows or callout numbers natively. Three options:
+
+1. **No annotations** — rely on surrounding markdown prose to direct attention. Simplest; accepts a loss of precision.
+2. **CSS overlay in Astro** — define hotspots in markdown using a custom component. Screenshots stay clean; annotations live alongside prose. More flexible, more code.
+3. **Post-processing** — run captured PNGs through a tool (Sharp, `@napi-rs/canvas`) that overlays arrows/numbers from a config. Most polished output, most moving parts.
+
+Recommended starting point: option 1. If prose isn't enough, graduate to option 2.
+
+### Sensitive content
+
+Every screenshot is reviewed for:
+- Client tour/page names that shouldn't appear in public docs
+- Email addresses (Playwright API user is fine, real users aren't)
+- Internal URLs
+- Authentication tokens in dev tools (don't capture browser devtools)
+
+Prefer using seeded content (`Test Group Tours` tree branch) over real client content for captures.
+
+### File paths and git
+
+Screenshots committed to the repo under `docs/src/assets/screenshots/`. Pros: docs are self-contained, GitHub Pages serves them directly. Cons: PNGs bloat git history. Alternatives:
+
+- Store in git LFS — adds setup complexity
+- Generate at build time — defeats the "review the output" benefit
+- Commit anyway — probably fine for this size of project
+
+Commit anyway, revisit if repo size becomes a problem.
+
+### Videos/GIFs
+
+Playwright records `.webm`. Converting to `.gif` or `.mp4` requires ffmpeg. Scope: skip initially. Revisit only for genuinely flow-based things (drag-and-drop) that screenshots can't convey. Keep under 15 seconds — easier to re-record, smaller files, easier on readers.
+
+---
+
+## Implementation sketch
+
+```typescript
+// tests/docs-screenshots/helpers/capture.ts
+export async function capture(page: Page, name: string, options?: CaptureOptions) {
+  const docPage = options?.docPage ?? 'usage';
+  const outputPath = path.join(
+    'docs/src/assets/screenshots',
+    docPage,
+    `${name}.png`
+  );
+  await page.screenshot({
+    path: outputPath,
+    fullPage: false,
+    ...options,
+  });
+}
+
+// tests/docs-screenshots/usage.screenshots.ts
+test.use({ viewport: { width: 1440, height: 900 } });
+
+test('usage.md flow', async ({ page }) => {
+  await page.goto('/umbraco');
+  await expect(page.getByText('Content')).toBeVisible();
+
+  // Navigate to parent node
+  await page.getByLabel('Expand child items for Home').click();
+  await page.getByText('Test Group Tours').click();
+  await capture(page, '01-content-tree');
+
+  // Open actions menu
+  await page.getByLabel('Open actions menu').click();
+  await capture(page, '02-actions-menu');
+
+  // Click Create from Source
+  await page.getByText('Create Document from Source').click();
+  await capture(page, '03-blueprint-picker');
+
+  // ... continue through the flow
+});
+```
+
+Markdown consumes them like:
+
+```markdown
+![Content tree with Test Group Tours node](../assets/screenshots/usage/01-content-tree.png)
+
+Click the **"..."** button on the parent node to open the actions menu.
+
+![Actions menu open with Create Document from Source highlighted](../assets/screenshots/usage/02-actions-menu.png)
+```
+
+---
+
+## Running and regenerating
+
+Scripts in `package.json`:
+
+```json
+{
+  "scripts": {
+    "docs:screenshots": "playwright test --config=playwright.docs.config.ts",
+    "docs:screenshots:usage": "playwright test --config=playwright.docs.config.ts usage.screenshots"
+  }
+}
+```
+
+Separate Playwright config so these runs don't mix with E2E (different reporter, different base URL maybe, no retries).
+
+---
+
+## Cost / benefit
+
+**Cost:**
+- ~1 day to build the pipeline end-to-end for one page
+- ~2 hours per additional page after that
+- Ongoing maintenance when UI changes (but far less than manual re-capture)
+- Repo size growth from committed PNGs
+
+**Benefit:**
+- Docs that show what they describe
+- Screenshots stay current (one command to regenerate)
+- Onboarding improves materially for new workflow authors
+- A base for video snippets later if needed
+
+**Verdict:** High value when tackled properly. Not urgent — manual screenshots would also be fine short-term for the one or two pages that most need them. The automation pays back when you have 5+ pages needing imagery.
+
+---
+
+## Open questions
+
+1. **CI integration**: should the screenshot spec run on merge to `develop` to catch UI regressions that break captures? Or on-demand only? Default: on-demand. Automated runs would need a way to handle diffs.
+
+2. **Diff review**: when re-running, how do we catch unintended visual changes? Manual review of PR diff is the obvious answer; Playwright's visual comparison isn't suitable here (screenshots aren't assertions).
+
+3. **Multiple locales**: if UpDoc ever ships localised docs, do we regenerate screenshots per locale? Probably yes, with the spec parameterised on locale query string. Not a concern until localised docs exist.
+
+4. **Dark mode coverage**: future consideration — capture both themes and let Starlight switch between them via CSS `prefers-color-scheme`. More work, better UX. Park for now.
+
+---
+
+## Prior art to review before implementing
+
+- Astro Starlight's own docs — how they handle imagery
+- Umbraco docs (docs.umbraco.com) — screenshot-heavy, good reference for annotation style
+- Playwright's own docs — they dog-food their own tool for screenshots
+
+---
+
+## Related
+
+- See `CLAUDE.md` and `memory/playwright-testing.md` for existing Playwright conventions
+- `tests/e2e/auth.setup.ts` is the auth foundation this would build on
+- Screenshot automation would also make the `user-journeys.md` page dramatically more useful


### PR DESCRIPTION
## Summary

- New user-facing docs page explaining what happens to workflow mappings when the underlying blueprint changes (safe changes, gotchas, the duplicate-block-types edge case, recommended workflow)
- Planning note for future Playwright-driven screenshot automation — docs are text-heavy and would benefit from auto-regenerated screenshots
- CLAUDE.md updated to adopt the issue-first workflow used in sibling projects

Closes #17

## Test plan

- [ ] Docs site builds locally (verified: dev server running at localhost:4322)
- [ ] New page renders at `/UpDoc/updating-blueprints/`
- [ ] Sidebar entry appears under "Creating Documents from Source"
- [ ] GitHub Actions deploys docs to GitHub Pages on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)