### PR TITLE
Add docs-screenshot workflow planning and medium-zoom

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -15,6 +15,9 @@ export default defineConfig({
 				{ icon: 'github', label: 'GitHub', href: 'https://github.com/UmTemplates/UpDoc' },
 			],
 			customCss: ['./src/styles/custom.css'],
+			components: {
+				Head: './src/components/Head.astro',
+			},
 			sidebar: [
 				{ label: 'Introduction', slug: 'introduction' },
 				{ label: 'Setting Up a Workflow', slug: 'setup' },

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -11,6 +11,7 @@
         "@astrojs/starlight": "^0.38.2",
         "astro": "^6.0.8",
         "astro-mermaid": "^1.3.1",
+        "medium-zoom": "^1.1.0",
         "mermaid": "^11.13.0",
         "sharp": "^0.34.2"
       }
@@ -5043,6 +5044,12 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
+    },
+    "node_modules/medium-zoom": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/medium-zoom/-/medium-zoom-1.1.0.tgz",
+      "integrity": "sha512-ewyDsp7k4InCUp3jRmwHBRFGyjBimKps/AJLjRSox+2q/2H4p/PNpQf+pwONWlJiOudkBXtbdmVbFjqyybfTmQ==",
+      "license": "MIT"
     },
     "node_modules/mermaid": {
       "version": "11.13.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,6 +13,7 @@
     "@astrojs/starlight": "^0.38.2",
     "astro": "^6.0.8",
     "astro-mermaid": "^1.3.1",
+    "medium-zoom": "^1.1.0",
     "mermaid": "^11.13.0",
     "sharp": "^0.34.2"
   }

--- a/docs/src/components/Head.astro
+++ b/docs/src/components/Head.astro
@@ -1,0 +1,24 @@
+---
+import Default from '@astrojs/starlight/components/Head.astro';
+---
+
+<Default><slot /></Default>
+
+<script>
+  import mediumZoom from 'medium-zoom';
+
+  const attachZoom = () => {
+    mediumZoom('.sl-markdown-content img:not(.no-zoom)', {
+      background: 'rgba(0, 0, 0, 0.85)',
+      margin: 24,
+    });
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', attachZoom);
+  } else {
+    attachZoom();
+  }
+
+  document.addEventListener('astro:page-load', attachZoom);
+</script>

--- a/planning/DOCS_SCREENSHOT_WORKFLOW.md
+++ b/planning/DOCS_SCREENSHOT_WORKFLOW.md
@@ -1,0 +1,149 @@
+# Docs-with-Screenshots Workflow
+
+**Issue:** #23
+**Status:** Planning
+**Scope:** This document captures the workflow for producing UpDoc docs pages with automated Playwright screenshots. Two companion artefacts make the pattern portable beyond this project — see "Related artefacts" at the bottom.
+
+---
+
+## The workflow
+
+Seven steps. Roughly a half-day of elapsed time per docs page. The conversational walkthrough is the slowest part; the implementation tends to take about 30-45 minutes once we have a plan.
+
+### 1. Open a GitHub issue
+
+Before any writing, open an issue describing the docs page being written. Reference the issue in every commit and in the PR body. This keeps the GitHub project board accurate and gives future readers a single place to find all related work.
+
+Use the `documentation` label (and `enhancement` if appropriate).
+
+### 2. Conversational walkthrough
+
+With the test site running and the relevant feature visible, walk through the flow step by step with Claude. Describe what's on screen, what you do, what changes, in natural language. Claude takes notes, asks clarifying questions, and flags potential screenshot moments with 📸.
+
+Keep the test site on a stable branch — don't switch branches mid-walkthrough or the UI might change under you.
+
+### 3. Planning doc (faux-flow)
+
+Claude writes `planning/USER_FLOW_<PAGE_NAME>.md` — a numbered step-by-step walkthrough of the flow with screenshot markers. Dual-purpose: source for the real docs page, and script for the Playwright spec.
+
+Review it, answer any open questions, approve.
+
+### 4. Docs page
+
+Claude turns the planning doc into `docs/src/content/docs/<page-name>.md` — real, polished prose with image references to `../../assets/screenshots/<page-name>/<nn>-<name>.png`.
+
+**Critical: use `../../assets/`, not `../assets/`.** The image path is resolved relative to the markdown file's location (`docs/src/content/docs/`), so two levels of `..` are needed to reach `docs/src/assets/`. Astro's build fails on this silently in local dev but catches it on CI. (Lessons learned from #21/#22.)
+
+Add the new page to `docs/astro.config.mjs` sidebar.
+
+### 5. Playwright spec
+
+Claude writes `src/UpDoc/wwwroot/App_Plugins/UpDoc/tests/e2e/<page-name>.screenshots.ts`. The spec drives the same flow, captures a screenshot at each 📸 marker, saves to `docs/src/assets/screenshots/<page-name>/`.
+
+**Key patterns from UpDoc experience:**
+
+- `test.use({ viewport: { width: 1440, height: 900 } })` — fixed viewport for consistency
+- Fixed workflow/content names (no timestamps) for stable screenshot captions
+- Delete-if-exists at spec start so re-runs are idempotent
+- Scope sidebar queries to the custom element (`const sidebar = page.locator('create-workflow-sidebar')`) to avoid strict-mode violations with the tree or other panels
+- Native `<select>` dropdowns cannot be screenshotted in the open state (the menu is OS-drawn, outside the DOM) — capture the closed state and describe options in prose
+- UUI `<uui-card-media select-only>` cards don't respond to `.click()` — their selection model uses shadow DOM events that we haven't cracked yet (see #20)
+
+**Run with:** `npx playwright test <page-name>.screenshots --project=docs-screenshots --reporter=line`
+
+### 6. Iterate
+
+Selectors are best-guess first time. Expect to re-run the spec several times, fixing one selector per iteration. Each run takes ~15-60 seconds depending on how far it gets before failing.
+
+Common fixes:
+- `getByText()` returns multiple matches → scope to a parent element
+- Placeholder text matches both an outer component and the inner input → use `.first()` or target the `<input>` directly
+- An action button's label depends on state (e.g. "Include all pages" vs "Include 1 page") → assert the current expected label, wait for state changes
+
+### 7. Ship
+
+When the spec runs clean, commit everything together: the PNGs, the markdown, the spec. Push, open PR, merge. GitHub Actions deploys docs to Pages automatically on merge to main.
+
+Close the issue (PR body's `Closes #NN` handles this, but verify — it sometimes doesn't fire).
+
+---
+
+## UpDoc-specific bits
+
+These are things the generic guide (in the standalone repo) won't have, because they're specific to this project's test site and content.
+
+**Test site:**
+
+- URL: `https://localhost:44390/umbraco`
+- Run with: `dotnet run --project src/UpDoc.TestSite/UpDoc.TestSite.csproj` — NOT `dotnet watch` (restarts mid-run)
+- Must be running before any spec starts
+
+**Playwright API user:**
+
+- Email: `play.wright@email.com`
+- Credentials in `src/UpDoc/wwwroot/App_Plugins/UpDoc/.env` — never hardcoded
+- Auth handled by `tests/e2e/auth.setup.ts` which saves storage state
+
+**Sample content reserved for screenshots:**
+
+- Workflow name: `Docs Screenshot Test PDF Workflow` (alias: `docsScreenshotTestPdfWorkflow`)
+- Sample PDF: `TTM5063 Wensum Flemish Bruges Antwerp Ghent lo.pdf` in Media > PDF > Wensum
+- Content tree root: `Home`
+- Document type for PDF workflows: `Tailored Tour` / `[Tailored Tour Blueprint]`
+
+**Existing reference spec:** `tests/e2e/creating-a-workflow.screenshots.ts` — copy-paste starting point for new pages.
+
+**Playwright config:** `docs-screenshots` project is already defined in `playwright.config.ts`. Scoped to `*.screenshots.ts` files.
+
+---
+
+## Screenshot output convention
+
+```
+docs/src/assets/screenshots/
+  <docs-page-slug>/
+    01-<first-moment>.png
+    02-<second-moment>.png
+    ...
+```
+
+Filenames use `nn-name.png` so they sort correctly in the folder. Slug matches the markdown filename (e.g. `creating-a-workflow.md` → `creating-a-workflow/`).
+
+---
+
+## When to NOT automate the screenshots
+
+Not everything needs a Playwright spec. Rough rules:
+
+- **< 3 screenshots on a page** — just take them manually. Automation overhead exceeds the payoff.
+- **One-off reference screenshots** (e.g. "here's what the NuGet package page looks like") — manual, single PNG in `docs/src/assets/`.
+- **Screenshots of external tools** (Figma, VS Code, Umbraco admin UIs we don't test against) — manual.
+
+Automate when the docs page walks through a flow in **our** UI, has **four or more** screenshot moments, and is expected to need regeneration when the UI changes.
+
+---
+
+## Known limitations
+
+Will improve over time as we hit them:
+
+- **Native `<select>` open state** — can't screenshot the OS-drawn dropdown menu. Mitigation: describe options in prose.
+- **UUI `<uui-card-media select-only>`** — programmatic selection doesn't fire via standard click or event dispatch. Tracked in #20.
+- **Animations / transient states** — capturing a toast fade-in, a modal slide-in, requires careful `waitFor` timing. Not a blocker but needs per-case attention.
+- **Video** — Playwright can record `.webm` but we haven't used it. Future enhancement.
+
+---
+
+## Related artefacts
+
+**Global Claude memory** — brief pattern description added to `~/.claude/CLAUDE.md` so any future Claude in any project knows this workflow exists. Written as part of #23.
+
+**Standalone guide repo** (future) — `UmTemplates/docs-screenshot-guide` or similar. Generic template, no project specifics. Projects reference it from their CLAUDE.md.
+
+---
+
+## Open questions
+
+1. **Do we regenerate screenshots on every merge to main, or only on-demand?** Default: on-demand (one command the maintainer runs). Automating regeneration in CI means we need to solve: how to diff PNGs in the PR review, what to do when the spec breaks because of a UI change (does CI go red?).
+2. **Should the standalone guide repo include the Playwright helper as an npm package?** Probably not yet — the helper is thin enough to copy-paste. Revisit if we end up maintaining 3+ projects using this pattern.
+3. **Medium-zoom** — see `planning/MEDIUM_ZOOM_INTEGRATION.md` for the separate decision on whether to add click-to-enlarge to the docs images.

--- a/planning/MEDIUM_ZOOM_INTEGRATION.md
+++ b/planning/MEDIUM_ZOOM_INTEGRATION.md
@@ -1,0 +1,124 @@
+# Medium-Zoom Integration
+
+**Issue:** #24
+**Status:** Planning
+**Scope:** Add [medium-zoom](https://github.com/francoischalifour/medium-zoom) to the Starlight docs site so readers can click screenshots to enlarge them.
+
+---
+
+## Why medium-zoom
+
+Screenshots in the docs are ~1440px wide source images rendered inline at page width (~700-900px). Detail is lost without zoom. Options:
+
+| Option | Size | Pros | Cons |
+|--------|------|------|------|
+| medium-zoom | ~3 KB | Zero config, keyboard + mobile handled, works with Starlight | Only zoom, no galleries |
+| PhotoSwipe | ~30 KB | Full gallery features, swipe between images | Overkill for docs |
+| DIY CSS/JS | variable | Full control | Reinvents the wheel |
+| Do nothing | 0 KB | Simplest | Poor reading experience |
+
+**Chosen: medium-zoom.** Smallest, most battle-tested, used by Next.js docs, React docs, many Starlight sites.
+
+---
+
+## Decisions
+
+### Scope: every image
+
+Apply medium-zoom globally to every `<img>` in docs pages. Not just screenshots. Reasoning:
+
+- Any inline image in docs benefits from zoom
+- Opt-in would require adding a class (or a Starlight component override) to every screenshot — fragile, easy to forget
+- The opt-out is trivial if we ever need to exclude an image (add `no-zoom` class)
+
+### Integration: global script in Starlight layout
+
+Starlight supports [component overrides](https://starlight.astro.build/guides/overriding-components/). The cleanest place to add medium-zoom is the `Head.astro` override — a `<script>` that activates medium-zoom on all images once the page has loaded.
+
+Pseudocode:
+
+```astro
+---
+import Default from '@astrojs/starlight/components/Head.astro';
+---
+<Default><slot /></Default>
+<script>
+  import mediumZoom from 'medium-zoom';
+  mediumZoom('img:not(.no-zoom)', {
+    background: 'rgba(0, 0, 0, 0.85)',
+    margin: 24,
+  });
+</script>
+```
+
+### Mobile behaviour
+
+medium-zoom handles mobile natively — tap to enlarge, tap again to close, pinch-zoom while open. Verify during testing that this still works (Starlight doesn't interfere).
+
+### Accessibility
+
+medium-zoom provides keyboard support out of the box:
+
+- **Esc** — close the zoomed image
+- **Focus** — zoomed image gets focus; background receives `aria-hidden`
+- **Alt text** — preserved (zoom doesn't replace the original `<img>`, it clones it)
+
+Spot-check with a screen reader during review.
+
+### Scroll-while-open
+
+medium-zoom closes the zoomed image when the user scrolls. This is standard behaviour. Good default — prevents awkward partial-scroll states.
+
+### Dark mode
+
+Check that the zoom background contrasts with both Starlight themes (light / dark). `rgba(0, 0, 0, 0.85)` should be fine in both but verify visually.
+
+---
+
+## Implementation steps
+
+Order matters — keep each step independently committable.
+
+1. **Install package** — `cd docs && npm install medium-zoom`
+2. **Create Head override** — `docs/src/components/Head.astro` extending the default Starlight `Head` component
+3. **Tell Starlight to use it** — add `components: { Head: './src/components/Head.astro' }` to `starlight()` config in `astro.config.mjs`
+4. **Add the zoom script** — inside the override, a `<script>` tag invoking `mediumZoom()`
+5. **Verify locally** — `npm run dev`, click a screenshot on the Creating a Workflow page
+6. **Verify mobile** — open the local dev server via IP on a phone, tap a screenshot
+7. **Verify dark mode** — toggle theme in the header, zoom a screenshot
+8. **Ship** — commit, push, PR to main, merge, deploy
+
+---
+
+## Risks
+
+- **Starlight API churn** — `Head.astro` override is a supported extension point but could change in major Starlight versions. Mitigation: pin Starlight version in `package.json`, upgrade deliberately. Low risk — this is a documented API.
+- **Conflict with Starlight's own scripts** — Starlight's theme toggle and navigation use client-side JS. medium-zoom operates on `<img>` tags independently; unlikely to conflict but verify in practice.
+- **Screenshot file size** — zoomed images are served at full resolution. Our PNGs are ~100KB each; at full-screen they're readable and load instantly. No action needed.
+- **SSR considerations** — `mediumZoom()` runs client-side (it touches `document`). Astro's `<script>` tag runs on the client by default; no SSR issue. Don't accidentally move it to frontmatter.
+
+---
+
+## Testing checklist
+
+- [ ] Click a screenshot — zooms smoothly
+- [ ] Click the dimmed background — closes
+- [ ] Press Esc — closes
+- [ ] Scroll — closes
+- [ ] Mobile tap — zooms
+- [ ] Mobile pinch while zoomed — works
+- [ ] Dark mode — zoom background contrasts correctly
+- [ ] Alt text preserved on zoomed image
+- [ ] No console errors on page load
+- [ ] No console errors when closing zoom
+- [ ] Works on pages with no images (no crashes on init)
+- [ ] Non-screenshot images also zoom (logo? probably don't want this — add `no-zoom` class if needed)
+
+---
+
+## Out of scope
+
+- **Galleries** — if we ever need multi-image carousels, revisit PhotoSwipe or build on medium-zoom's API. Not needed now.
+- **Captions in the zoom view** — medium-zoom shows `alt` text as caption by default. Adequate. Custom caption styling is a future polish.
+- **Zoom on hover** — tempting but overrides natural click behaviour. Skip.
+- **Keyboard activation** — medium-zoom requires a click/tap to zoom, not keyboard. Triggering zoom via keyboard would need custom work. Out of scope — alt text and context serve keyboard users fine.


### PR DESCRIPTION
## Summary

- **Planning docs** for the docs-with-screenshots workflow (to be reused across projects) and for medium-zoom integration
- **medium-zoom implementation** — screenshots in docs are now click-to-enlarge

Closes #24
Refs #23 (planning doc shipped; global CLAUDE.md update + standalone guide repo still to come)

## Test plan

- [x] \`npm run build\` in docs/ succeeds — 83 pages built, 11 screenshots auto-optimised to WebP
- [ ] Post-deploy: click a screenshot on the live Creating a Workflow page — zooms
- [ ] Click dimmed background or press Esc — closes
- [ ] Mobile: tap to zoom, pinch works
- [ ] Dark mode — zoom background contrasts

🤖 Generated with [Claude Code](https://claude.com/claude-code)