### PR TITLE
Remove local-machine paths from public docs + add build-time guardrail

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,20 @@ If adding a new source file:
 1. Create corresponding `.md` file in `docs/src/content/docs/source-files/`
 2. Add entry to the `sidebar` array in `docs/astro.config.mjs`
 
+## No Local-Machine Paths in Public Docs
+
+The `docs/` directory is published to GitHub Pages and indexed by search engines. Never include references to local-machine paths in any file under `docs/src/content/`:
+
+- No absolute Windows paths (`D:\Users\deanl\...`, `C:\...`)
+- No absolute Unix/macOS user paths (`/home/deanl/...`, `/Users/deanl/...`)
+- No references to personal usernames in file paths
+
+When referring to external resources (e.g. "the Umbraco CMS source code"), link to the public GitHub URL and instruct readers to clone it locally themselves. The specific path on the maintainer's machine is irrelevant to docs readers.
+
+**This is enforced automatically** — `docs/scripts/check-no-local-paths.mjs` runs as part of `npm run build` and fails the build if any blocked pattern appears in the published output. If the check flags a false positive, update the `ALLOWLIST` in the script; don't disable the check.
+
+Developer-facing files outside `docs/src/content/` (e.g. `CLAUDE.md`, `planning/*.md`, this project's own README) **may** legitimately reference local paths when describing the maintainer's environment. Those files are not published.
+
 ## Naming Conventions
 
 | Context | Format | Value |

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,9 +5,10 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro build",
+    "build": "astro build && npm run check:no-local-paths",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "check:no-local-paths": "node scripts/check-no-local-paths.mjs"
   },
   "dependencies": {
     "@astrojs/starlight": "^0.38.2",

--- a/docs/scripts/check-no-local-paths.mjs
+++ b/docs/scripts/check-no-local-paths.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Scans the built Astro output (docs/dist) for references to local-machine
+ * paths that must not appear in public docs. Exits non-zero if anything is
+ * found, which fails the deploy workflow.
+ *
+ * Run after `astro build` has produced `dist/`.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const DIST = 'dist';
+const FILE_EXTENSIONS = ['.html', '.js', '.css', '.json', '.xml'];
+
+// Patterns that must never appear in public docs.
+// Tuned to avoid false positives on legitimate content (e.g. localhost in dev
+// setup instructions is fine; Windows-style drive letters in paths are not).
+const BLOCKED_PATTERNS = [
+  { name: 'Windows user path', regex: /[A-Za-z]:[\\/]Users[\\/][^\s<>"'`,]+/ },
+  { name: 'Unix home path with username', regex: /\/home\/(?!runner\b)[a-z0-9_-]+\/[^\s<>"'`,]+/ },
+  { name: 'macOS user path', regex: /\/Users\/[a-z0-9_-]+\/[^\s<>"'`,]+/i },
+];
+
+// Files or paths that are allowed to contain matches (none currently).
+const ALLOWLIST = [];
+
+function* walk(dir) {
+  const entries = readdirSync(dir);
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    const stats = statSync(full);
+    if (stats.isDirectory()) {
+      yield* walk(full);
+    } else if (FILE_EXTENSIONS.some((ext) => full.endsWith(ext))) {
+      yield full;
+    }
+  }
+}
+
+let violationsFound = 0;
+
+for (const file of walk(DIST)) {
+  if (ALLOWLIST.some((allow) => file.includes(allow))) continue;
+
+  const content = readFileSync(file, 'utf8');
+  for (const { name, regex } of BLOCKED_PATTERNS) {
+    const match = content.match(regex);
+    if (match) {
+      console.error(`BLOCKED (${name}) in ${file}:`);
+      console.error(`  ${match[0]}`);
+      violationsFound++;
+    }
+  }
+}
+
+if (violationsFound > 0) {
+  console.error(`\nFAIL — ${violationsFound} local-path reference(s) found in public docs.`);
+  console.error('Remove personal paths before merging. See issue #26.');
+  process.exit(1);
+}
+
+console.log('OK — no local-machine paths in public docs.');

--- a/docs/src/content/docs/tooling/umbraco-skills/index.md
+++ b/docs/src/content/docs/tooling/umbraco-skills/index.md
@@ -49,7 +49,7 @@ Skills for every Umbraco backoffice extension type:
 ## Critical Lesson: Skills Are Supplementary
 
 :::caution[Always verify against the Umbraco CMS source code]
-Skills provide excellent starting guidance, but the **Umbraco CMS source code** is the definitive reference. The local clone at `d:\Users\deanl\source\repos\Umbraco Extensions\Umbraco-CMS` must be consulted for:
+Skills provide excellent starting guidance, but the **Umbraco CMS source code** ([github.com/umbraco/Umbraco-CMS](https://github.com/umbraco/Umbraco-CMS)) is the definitive reference. Clone it locally and consult it for:
 :::
 
     - How Umbraco itself implements similar features


### PR DESCRIPTION
## Summary

- **Cleanup**: one occurrence of a hardcoded local clone path (\`d:\Users\deanl\...\Umbraco-CMS\`) replaced with a public GitHub URL on the umbraco-skills tooling docs page.
- **Prevention**: new \`docs/scripts/check-no-local-paths.mjs\` scans built HTML/JS/CSS for Windows, macOS, and Unix user paths and fails the build if any are found. Chained into \`npm run build\` so every CI deploy enforces it.
- **Documentation**: \`CLAUDE.md\` updated with a No-Local-Paths rule referencing the guardrail.

Closes #26

## Test plan

- [x] \`npm run build\` passes cleanly on the fixed docs
- [x] Script catches a deliberately injected bad path (verified locally by appending a test string and re-running)
- [ ] Post-merge: GitHub Actions build succeeds, docs deploy, umbraco-skills page shows the new GitHub link

🤖 Generated with [Claude Code](https://claude.com/claude-code)