### PR TITLE
Add July 2026 sprint plan and non-text field mapping brief

### DIFF
--- a/planning/BRIEF_NON_TEXT_FIELD_MAPPING.md
+++ b/planning/BRIEF_NON_TEXT_FIELD_MAPPING.md
@@ -1,0 +1,127 @@
+# Brief: support mapping into non-text destination fields (integer, date)
+
+Raised: 2026-07-18, from the Tailored Travel project.
+Status: brief for triage — not yet an agreed plan.
+
+## Summary
+
+UpDoc's PDF workflow can only map extracted content into **text**, **textArea**
+and **richText** document-type properties. Integer, date, and other typed
+properties are silently dropped from the destination mapping, so they can never
+be populated on import.
+
+This is the first real-world workflow to need typed fields, so the gap has not
+surfaced before. It now blocks a live use case (see "Motivating case").
+
+## Root cause (confirmed in source)
+
+`src/UpDoc/Services/DestinationStructureService.cs`:
+
+**1. The allow-list excludes everything but text.** Lines 30-33:
+
+```csharp
+private static readonly HashSet<string> TextMappableTypes = new(StringComparer.OrdinalIgnoreCase)
+{
+    "text", "textArea", "richText"
+};
+```
+
+`BuildFieldIfEligible` (lines 172-193) maps the editor alias, then drops any
+field whose mapped type is not in that set (lines 176-180):
+
+```csharp
+var fieldType = MapEditorAlias(propertyType.PropertyEditorAlias);
+if (!TextMappableTypes.Contains(fieldType))
+{
+    return null;   // field never offered as a mapping target
+}
+```
+
+The same filter applies to block properties (lines 364-376).
+
+**2. `MapEditorAlias` already recognises the types — they just aren't allowed
+through.** Lines 444-456:
+
+```csharp
+private static string MapEditorAlias(string editorAlias) => editorAlias switch
+{
+    "Umbraco.TextBox" => "text",
+    "Umbraco.TextArea" => "textArea",
+    "Umbraco.RichText" or "Umbraco.TinyMCE" => "richText",
+    "Umbraco.Integer" or "Umbraco.Decimal" => "number",
+    "Umbraco.DateTime" => "date",
+    "Umbraco.TrueFalse" => "boolean",
+    "Umbraco.MediaPicker3" => "mediaPicker",
+    "Umbraco.ContentPicker" or "Umbraco.MultiNodeTreePicker" => "contentPicker",
+    "Umbraco.BlockList" => "blockList",
+    _ => "text"
+};
+```
+
+So `Umbraco.Integer` → `"number"` (dropped by the filter), and
+**`Umbraco.DateOnly` is not in the switch at all** — it falls through to
+`_ => "text"`, which is why a DateOnly field currently sneaks in *as text*
+(inconsistent, and it won't coerce to a real date on write).
+
+## What "done" looks like
+
+At minimum, integer and date properties should be offerable as mapping targets
+and receive a correctly-typed value on import. Concretely:
+
+1. Add `"number"` and `"date"` to `TextMappableTypes` (or replace the allow-list
+   with an explicit unsupported-list — design choice).
+2. Add `Umbraco.DateOnly` to `MapEditorAlias` so it maps to `"date"`, not the
+   text fallback. Consider `Umbraco.DateTime` and `Umbraco.DateOnly` together.
+3. **The write/apply path must coerce the captured string to the target type.**
+   A capture like `1,999` must land in an integer property as `1999`, and
+   `29 September 2027` in a DateOnly property as a real date. This is the part
+   that needs the most care — find where the mapped value is written onto the
+   content property and ensure typed conversion happens there.
+
+## Open questions for the implementer
+
+- **Where is the value applied to the content property?** It was not obvious in
+  the server-side services (`WorkflowService`, `ContentTransformService`). It
+  may run client-side (the map executes in the browser, then content is created
+  via the Management API). The fix likely spans both the server field filter and
+  the client apply step — confirm before scoping.
+- **Cleanup responsibility.** UpDoc already has a regex find-and-replace in the
+  rule editor. Should the raw→typed cleaning (strip `,` from price, strip ordinal
+  from a date) stay the editor's job via find-and-replace, or should the typed
+  write coerce leniently? Recommend: editor find-and-replace does the string
+  cleanup, the write does a strict parse and fails loudly if the cleaned string
+  is not valid for the type.
+- **AcceptsFormats / UI.** `GetAcceptsFormats` (lines 458-463) only knows text
+  shapes. A number/date target may want its own accepted formats and a different
+  editor affordance in the mapping UI.
+- **Other typed editors.** `boolean`, `mediaPicker`, `contentPicker` are mapped
+  by `MapEditorAlias` but also excluded. Out of scope for this brief (no current
+  need) but worth noting the same filter blocks them — a general "typed field
+  mapping" design would cover all of them rather than special-casing number/date.
+
+## Motivating case (Tailored Travel)
+
+A tailored-tour PDF has a one-line strapline, e.g.:
+
+```
+6 days from £1,999   Departs 29th September 2027
+```
+
+The destination doc type splits this into three typed properties:
+
+| Property | Editor | Value |
+|---|---|---|
+| `pagePropertyTourDuration` | Umbraco.Integer | `6` |
+| `pagePropertyTourPriceFrom` | Umbraco.Integer | `1999` |
+| `pagePropertyTourDepartureDate` | Umbraco.DateOnly | `2027-09-29` |
+
+The source side works: UpDoc already isolates the strapline as a discrete
+section, and three anchor-based rules with regex find-and-replace can capture
+and clean each value (before `day`; after `£` with `,`→``; after `Depart` with
+`(\d{1,2})(st|nd|rd|th)`→`$1`). The **only** blocker is the destination: the two
+integer fields are never offered, and the date field is mis-typed as text.
+
+## Suggested next step
+
+Create a GitHub issue on the UpDoc repo from this brief (`gh issue create`),
+then plan the fix per the project's planning-doc convention.

--- a/planning/SPRINT_2026_07.md
+++ b/planning/SPRINT_2026_07.md
@@ -1,0 +1,168 @@
+# Sprint: July 2026 — UpDoc improvements
+
+Created: 2026-07-18 (Saturday).
+Target: work ready to adopt Monday morning, 2026-07-20.
+Status: agreed, not started.
+
+## Context
+
+UpDoc is in live use on a client project, where it has successfully imported
+web pages and PDF documents. Development was paused specifically so that
+in-progress UpDoc work could not destabilise that project.
+
+Everything in this sprint eventually ships back into that project. **The
+governing constraint is that a release must not break it.** Ordering below is
+lowest-risk-first, not most-interesting-first.
+
+## Release plan
+
+Four releases, smallest and safest first. Each is independently adoptable.
+
+| Release | Contains | Risk to live project |
+|---|---|---|
+| **R1 — docs security** | #36 | None. Docs toolchain only. |
+| **R2 — working practice** | #35 | None. Docs only. |
+| **R3 — fixes** | #38, #42, #43 | Low. Touches the RCL, gated by #40. |
+| **R4 — features** | #37, #41, #34 | Real. Adopt when the project can absorb it. |
+
+Design work (#44) produces a document, not a release.
+
+## Priority for Monday morning
+
+**Minimum viable outcome:** R1 and R3 — docs secure, refresh/regenerate fixed.
+Everything beyond that is a bonus.
+
+If the weekend runs short, stop after R3. R4 is the part that touches import
+behaviour, and shipping it rushed is precisely the risk this sprint exists to
+avoid.
+
+---
+
+## Saturday
+
+### 1. Astro 7 / Starlight 0.41 + security advisories — #36
+
+First, deliberately. A live high-severity advisory should not wait behind a
+working-practice decision.
+
+- [ ] Enable Dependabot alerts on the repository (currently **disabled** — this
+      is why advisory emails named UmBootstrap and not UpDoc)
+- [ ] Upgrade Astro 6.0.8 → 7.1.1 and Starlight 0.38.2 → 0.41.3 together
+      (Starlight 0.41 declares `astro: ^7.0.2` as a peer, they cannot move apart)
+- [ ] Verify `astro-mermaid` 1.x → 2.x — major bump, docs use mermaid diagrams
+- [ ] `npm run build` passes including `check:no-local-paths`
+- [ ] `npm audit` clean or remaining items justified
+- [ ] Spot-check deployed site: nav, Pagefind search, diagrams, screenshots
+- [ ] **Release R1**
+
+Note: the `.gitattributes` LF/CRLF protection described in the global docs
+convention is **not applicable** — UpDoc does not commit `docs/dist/`
+(verified: 0 files tracked). Do not add those rules.
+
+### 2. Documentation worktree methodology — #35
+
+- [ ] Decide permanent branch name
+- [ ] Create worktree, rewire `docs.yml`, verify a test deploy
+- [ ] Reconcile the existing `origin/docs/updating-blueprints` branch
+- [ ] Update `CLAUDE.md` so future sessions do not start from stale assumptions
+- [ ] **Release R2**
+
+Decided: **one site, not two.** UpDoc is developer-facing, but the Create from
+Source flow is genuinely editor-facing — handle that as internal separation
+within one site rather than running two.
+
+### 3. Release-safety baseline — #40
+
+The gate that makes everything after it verifiable. Must be captured from
+current `develop`, i.e. from known-good code **before** any RCL change lands.
+
+- [ ] Agree the required-pass spec set
+- [ ] Golden-file check for at least one PDF and one web source
+- [ ] Write the release checklist
+
+---
+
+## Sunday
+
+### 4. Refresh/regenerate wiring — #38
+
+The largest of the fix items, and the one with confirmed user-visible impact.
+
+- [ ] **Confirm first:** log in `setRefreshHandler` while switching tabs, to
+      verify the single-slot clobber is the real cause. Inferred from code
+      shape, not observed.
+- [ ] Guard the handler null-out
+- [ ] Stop Refresh mutating stored state on the Source view
+- [ ] Surface the discarded `reconciliation` payload; reload Map view after
+      destination regenerate/change
+- [ ] Fix stale area detection on non-PDF re-extract
+- [ ] Decide per dead endpoint: wire up or delete (four of them)
+
+### 5. Two bugs — #42, #43
+
+- [ ] `convertRichTextFields` missing `identifyBy`-matched blocks — check the
+      live project's `map.json` files for `contentTypeKey`-less mappings first,
+      since that determines whether this is live or latent
+- [ ] `markdownToHtml` unescaped fallback paths
+- [ ] **Release R3**
+
+### 6. Typed field design — #44
+
+Design only. No implementation this weekend.
+
+- [ ] Inventory every Umbraco 17 property editor with an explicit decision:
+      mappable / not mappable / deferred
+- [ ] Define the coercion contract per mappable type
+- [ ] Decide parse-failure behaviour
+- [ ] Replace the silent `_ => "text"` fallback with explicit handling
+- [ ] Write to `planning/`, review before any code
+
+---
+
+## Monday (contingency, not plan)
+
+Only if Saturday and Sunday overrun. Prefer deferring to next week over
+rushing anything that touches the import path.
+
+---
+
+## Deferred to a later release (R4)
+
+Not this weekend. Each needs #40 in place first.
+
+- **#39** — typed-field test fixture. Blocks #34; add typed properties to the
+  existing test site rather than importing the client site (see issue for the
+  reasoning against importing Tailored Travel).
+- **#37** — regex find-and-replace + ReDoS protection. **Prerequisite for #34.**
+- **#41** — extract duplicated apply logic from the two bridge files.
+- **#34** — typed destination fields, integer/date subset of the #44 design.
+
+---
+
+## Corrections made during planning
+
+Two working assumptions turned out to be wrong. Both were worth finding before
+implementation rather than during it.
+
+**1. The #34 brief's premise is false.** It states "the source side works... the
+only blocker is the destination". Find-and-replace is **literal string replace,
+not regex** (`ContentTransformService.cs:690`). The brief's own worked example,
+`(\d{1,2})(st|nd|rd|th)` → `$1`, cannot work — `$1` would be inserted literally.
+**#37 is a prerequisite for #34**, not a parallel improvement.
+
+**2. The apply path is entirely client-side.** The brief's main open question is
+answered: there is no C# write path. The document is created by the frontend
+mutating a scaffold in-browser and POSTing to the Management API. Coercion
+belongs in `#convertRichTextFields`, which is already type-driven.
+
+**3. Dependabot alerts are disabled on the UpDoc repository.** Advisory emails
+named UmBootstrap because UpDoc reports nothing at all, despite the
+vulnerabilities being present.
+
+## Open questions
+
+- Parse-failure behaviour for typed fields (#44) — abort, skip-and-warn, or
+  block at preview? Recommend abort with a clear error over a silent `null`.
+- Whether #42 is live or latent in the client project — depends on whether any
+  `map.json` there has `identifyBy`-only mappings.
+- Golden files as committed JSON or Playwright snapshots (#40).


### PR DESCRIPTION
Planning documents only. No code changes.

## What this adds

**`planning/BRIEF_NON_TEXT_FIELD_MAPPING.md`** — was referenced by #34 but had never been committed, so the issue pointed at a file that did not exist on the remote.

**`planning/SPRINT_2026_07.md`** — the ordered index over issues #34-#44, sequenced lowest-risk-first because UpDoc is in live use on a client project and every release ships back into it.

## Corrections recorded during planning

Two working assumptions turned out to be wrong. Both are documented in the sprint plan and as comments on #34.

**1. The brief's premise is false.** It states "the source side works... the only blocker is the destination". Find-and-replace is **literal string replace, not regex** (`ContentTransformService.cs:690`), so the brief's own worked example — `(\d{1,2})(st|nd|rd|th)` → `$1` — cannot work. `$1` would be inserted literally. **#37 is therefore a prerequisite for #34**, not a parallel improvement.

**2. The apply path is entirely client-side.** The brief's main open question is answered: there is no C# write path. The document is created by the frontend mutating a scaffold in-browser and POSTing to the Management API. Typed coercion belongs in the TypeScript convert pass, which is already type-driven.

The brief is committed **as originally written**, with the corrections recorded separately rather than edited in — it is a point-in-time record of what was believed at the time.

Refs #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)