### PR TITLE
Set up docs worktree on permanent docs/site branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - main
+      - docs/site
     paths:
       - 'docs/**'
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -519,3 +519,6 @@ appsettings-schema.json
 
 # Umbraco runtime data
 **/umbraco/Data/
+
+# Git worktrees (docs worktree lives here)
+.worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,31 @@ d:\Users\deanl\source\repos\Umbraco Extensions\Umbraco-CMS
 - Document-related: `Umbraco-CMS/src/Umbraco.Web.UI.Client/src/packages/documents/`
 - Core extension types: `Umbraco-CMS/src/Umbraco.Web.UI.Client/src/packages/core/`
 
+## Documentation Worktree (READ BEFORE EDITING ANY DOCS FILE)
+
+Documentation is edited in a **git worktree**, never from the main working directory.
+
+```
+UpDoc/                     main working directory — code, on a feature branch
+UpDoc/.worktrees/docs/     docs worktree — always on docs/site
+```
+
+**Before editing any file under `docs/`, check the absolute path.** If it is not
+under `.worktrees/docs/`, you are in the wrong place. The two folders look
+identical in an editor; the path is the only way to tell.
+
+Editing `docs/` from the main working directory puts the change on a code
+feature branch, where it sits unpublished until that branch merges. That is the
+exact friction the worktree exists to remove.
+
+Commit and push docs changes as you make them, rather than batching. Pushing to
+`docs/site` deploys.
+
+Exception: documentation that is genuinely part of a code change (a source file
+and its reference page changing together) can stay in the feature branch.
+
+See `WORKTREES.md` for the full rules and rationale.
+
 ## Documentation (Astro Starlight)
 
 Documentation is built with Astro Starlight and deployed to GitHub Pages via GitHub Actions. The site is at `https://umtemplates.github.io/UpDoc/`.

--- a/WORKTREES.md
+++ b/WORKTREES.md
@@ -1,0 +1,104 @@
+# Worktrees
+
+UpDoc uses one git worktree, for documentation.
+
+```
+UpDoc/                     main working directory — code, on a feature branch
+UpDoc/.worktrees/docs/     docs worktree — always on docs/site
+```
+
+Both are the same repository. Two folders, two branches, one `.git`.
+
+## Why
+
+Documentation does not get written because it always competes with in-flight
+work for the same working directory. The thought arrives mid-feature, and
+acting on it means stashing, switching branch, losing your place. So it waits,
+and then it does not happen.
+
+The worktree removes that. When something needs documenting, open the docs
+worktree, write it, commit, push. The feature branch never moves. Nothing to
+stash, nothing to switch.
+
+It also means docs deploy the moment they are pushed, rather than waiting for a
+feature branch to merge. Since docs are often written *before* the code they
+describe, that matters.
+
+## The rules
+
+**1. Never edit `docs/` from the main working directory.**
+
+The same files exist on `develop`. Editing them there puts the change on a code
+feature branch, where it sits until that branch merges. Which is the friction
+this exists to remove.
+
+**2. Check the path before editing any docs file.**
+
+If it is under `docs/`, it belongs in the worktree. The two folders look
+identical in an editor — the path is the only thing that tells you where you
+are.
+
+**3. Commit and push docs changes as you make them.**
+
+Do not batch. Push to `docs/site` and it deploys. A docs change sitting
+uncommitted in the worktree has all the same problems as one sitting on a
+feature branch.
+
+**4. Docs that are genuinely part of a code change can stay with the code.**
+
+If a source file and its reference page change together, keep them in the same
+feature branch. The worktree is for documentation that stands alone, not a rule
+that docs may never travel with code.
+
+## Working in it
+
+```bash
+cd .worktrees/docs
+# edit, commit, push — deploys on push
+```
+
+First time only, the worktree needs its own `node_modules`:
+
+```bash
+cd .worktrees/docs/docs
+npm install
+```
+
+To preview locally:
+
+```bash
+cd .worktrees/docs/docs
+npm run dev
+```
+
+## Keeping it current
+
+`docs/site` is a permanent branch. It does not get deleted after merging.
+
+It will drift from `develop` over time, since code lands on `develop` and docs
+land on `docs/site`. That is fine — they are independent. If you want the docs
+worktree to have current code alongside it, merge `develop` into `docs/site`.
+
+```bash
+cd .worktrees/docs
+git merge develop
+```
+
+Docs changes flow the other way when convenient, but they do not have to. The
+site deploys from `docs/site` directly.
+
+## Deployment
+
+`.github/workflows/docs.yml` builds and deploys on push to `develop`, `main` or
+`docs/site`, whenever anything under `docs/` changes. All three publish to the
+same GitHub Pages site.
+
+Docs pushed to `docs/site` go live within a couple of minutes without touching
+`develop` or `main`.
+
+## Note for other projects
+
+Sibling projects run two worktrees, for developer docs and an editor manual on
+separate permanent branches, deployed to Cloudflare Pages. UpDoc has one public
+docs site on GitHub Pages and needs only one worktree. Same idea, smaller
+shape.


### PR DESCRIPTION
Closes #35

Documentation is now edited in a git worktree at `.worktrees/docs`, permanently checked out on a new `docs/site` branch, rather than from the main working directory.

## The problem

Documentation does not get written because the thought arrives mid-feature. Acting on it means stashing, switching branch, writing, switching back, finding your place. Small each time, fatal in aggregate.

Committing docs alongside each feature fails the same way — "I'll add it before I merge" is a promise made by someone about to be interrupted.

## What changed

- New permanent branch `docs/site`, checked out at `.worktrees/docs`
- `docs/site` added to the `docs.yml` deploy trigger
- `docs/site` added to the **`github-pages` environment branch allowlist** (see below)
- `.worktrees/` gitignored
- `WORKTREES.md` documents rules and rationale
- `CLAUDE.md` gains a path check before any docs edit

## Worth knowing: there were two gates, not one

Adding the branch to the workflow trigger was not sufficient. The first push to `docs/site` **built successfully but failed to deploy** — the `github-pages` environment had a branch allowlist containing only `develop` and `main`, and refused the deployment.

Fixed by adding `docs/site` to that allowlist. GitHub Pages itself needed no change: build type is still `workflow`, the site still serves from `gh-pages`, URL unchanged.

Anyone repeating this on another repo needs **both** changes.

## Verified

Full loop tested end to end: edited the About page in the worktree, committed, pushed to `docs/site`, deployed, confirmed live. No `develop`, no PR, no branch switching.

Deliberately smaller than the sibling-project pattern (two worktrees, two audiences, Cloudflare Pages with gating). UpDoc has one public docs site and needs one worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)