### PR TITLE
Bring sprint plan up to date after R1 and R2

### DIFF
--- a/planning/SPRINT_2026_07.md
+++ b/planning/SPRINT_2026_07.md
@@ -1,8 +1,8 @@
 # Sprint: July 2026 — UpDoc improvements
 
 Created: 2026-07-18 (Saturday).
+Last updated: 2026-07-18, after shipping R1 and R2.
 Target: work ready to adopt Monday morning, 2026-07-20.
-Status: agreed, not started.
 
 ## Context
 
@@ -11,158 +11,148 @@ web pages and PDF documents. Development was paused specifically so that
 in-progress UpDoc work could not destabilise that project.
 
 Everything in this sprint eventually ships back into that project. **The
-governing constraint is that a release must not break it.** Ordering below is
+governing constraint is that a release must not break it.** Ordering is
 lowest-risk-first, not most-interesting-first.
+
+---
+
+## Progress
+
+### ✅ R1 — docs security (SHIPPED, live)
+
+- **#36** Astro 6→7, Starlight 0.38→0.41, astro-mermaid 1→2. Docs advisories
+  **20+ → 0**. Verified against a pre-upgrade baseline: 84 pages identical,
+  all 11 mermaid diagrams render, Pagefind search working, zero console errors.
+- Dependabot alerts **enabled** — they had been off, which is why advisory
+  emails named UmBootstrap and not UpDoc.
+- "About This Documentation" page added.
+- Planning docs committed (this file and the #34 brief).
+
+### ✅ R2 — docs worktree (SHIPPED, live)
+
+- **#35** Permanent `docs/site` branch, worktree at `.worktrees/docs`.
+  `WORKTREES.md` written, `CLAUDE.md` updated with a path check.
+- Full loop verified: edit in worktree → push → live in ~2 minutes, without
+  touching `develop` or `main`.
+- **Gotcha worth remembering:** there were *two* gates. Adding `docs/site` to
+  the workflow trigger was not enough — the `github-pages` **environment** had
+  its own branch allowlist and refused the deploy after a successful build.
+  Both changes are needed. GitHub Pages itself needed no change.
+
+### ⬜ Remaining
+
+Nothing further is shipped. Everything below is open.
+
+---
 
 ## Release plan
 
-Four releases, smallest and safest first. Each is independently adoptable.
+| Release | Contains | Risk to live project | Status |
+|---|---|---|---|
+| **R1 — docs security** | #36 | None | ✅ shipped |
+| **R2 — docs worktree** | #35 | None | ✅ shipped |
+| **R3 — fixes** | #38, #42, #43, and consider #28, #15 | Low, gated by #40 | open |
+| **R4 — features** | #37, #41, #34 | Real | open |
+| **R5 — RCL security** | #51 | Real, ships to consumers | open |
 
-| Release | Contains | Risk to live project |
+Design work (#44) and the actions bump (#54) produce no release of their own.
+
+---
+
+## Next up
+
+### #40 — release-safety baseline ← **do this first**
+
+The gate that makes every RCL change verifiable. Must be captured from current
+`develop`, i.e. from known-good code before any RCL change lands.
+
+Two parts:
+1. Which E2E specs constitute the release gate
+2. Golden-file output for a representative PDF and web page, so *quality*
+   regressions are visible and not just crashes
+
+Everything below depends on this.
+
+**Open question for Dean:** is there a PDF that has historically been awkward
+to extract? That is a better canary than an easy one. If nothing springs to
+mind, the Winchester PDF already used in the specs is a fine start.
+
+### Then, in rough order
+
+| Issue | What | Notes |
 |---|---|---|
-| **R1 — docs security** | #36 | None. Docs toolchain only. |
-| **R2 — working practice** | #35 | None. Docs only. |
-| **R3 — fixes** | #38, #42, #43 | Low. Touches the RCL, gated by #40. |
-| **R4 — features** | #37, #41, #34 | Real. Adopt when the project can absorb it. |
-
-Design work (#44) produces a document, not a release.
-
-## Priority for Monday morning
-
-**Minimum viable outcome:** R1 and R3 — docs secure, refresh/regenerate fixed.
-Everything beyond that is a bonus.
-
-If the weekend runs short, stop after R3. R4 is the part that touches import
-behaviour, and shipping it rushed is precisely the risk this sprint exists to
-avoid.
+| **#38** | Refresh/regenerate wiring | Confirmed: Refresh can silently no-op. Consider merging with #28 and #15 — same territory. |
+| **#42** | `convertRichTextFields` misses `identifyBy`-matched blocks | Check the live project's `map.json` first — this may be biting silently already |
+| **#43** | `markdownToHtml` unescaped fallback | Small, self-contained |
+| **#39** | Typed-field test fixture | **Blocks #34** |
+| **#37** | Regex find-and-replace + ReDoS protection | **Prerequisite for #34** |
+| **#41** | Extract duplicated apply logic | Do before #34 so the fix is written once |
+| **#34** | Typed destination fields (integer, date) | Implements the #44 design |
+| **#44** | Design: all typed field mapping | Design only, no implementation |
+| **#51** | RCL security advisories incl. `pdfjs-dist` | Ships to consumers, needs #40 |
+| **#54** | Bump actions off Node 20 | Affects `release.yml`, not just docs. Org-wide. |
 
 ---
 
-## Saturday
+## Pre-existing issues not originally in this sprint
 
-### 1. Astro 7 / Starlight 0.41 + security advisories — #36
+These predate the sprint and were missed when it was first written. Two overlap
+directly with #38 and should be considered alongside it rather than separately:
 
-First, deliberately. A live high-severity advisory should not wait behind a
-working-practice decision.
-
-- [ ] Enable Dependabot alerts on the repository (currently **disabled** — this
-      is why advisory emails named UmBootstrap and not UpDoc)
-- [ ] Upgrade Astro 6.0.8 → 7.1.1 and Starlight 0.38.2 → 0.41.3 together
-      (Starlight 0.41 declares `astro: ^7.0.2` as a peer, they cannot move apart)
-- [ ] Verify `astro-mermaid` 1.x → 2.x — major bump, docs use mermaid diagrams
-- [ ] `npm run build` passes including `check:no-local-paths`
-- [ ] `npm audit` clean or remaining items justified
-- [ ] Spot-check deployed site: nav, Pagefind search, diagrams, screenshots
-- [ ] **Release R1**
-
-Note: the `.gitattributes` LF/CRLF protection described in the global docs
-convention is **not applicable** — UpDoc does not commit `docs/dist/`
-(verified: 0 files tracked). Do not add those rules.
-
-### 2. Documentation worktree methodology — #35
-
-- [ ] Decide permanent branch name
-- [ ] Create worktree, rewire `docs.yml`, verify a test deploy
-- [ ] Reconcile the existing `origin/docs/updating-blueprints` branch
-- [ ] Update `CLAUDE.md` so future sessions do not start from stale assumptions
-- [ ] **Release R2**
-
-Decided: **one site, not two.** UpDoc is developer-facing, but the Create from
-Source flow is genuinely editor-facing — handle that as internal separation
-within one site rather than running two.
-
-### 3. Release-safety baseline — #40
-
-The gate that makes everything after it verifiable. Must be captured from
-current `develop`, i.e. from known-good code **before** any RCL change lands.
-
-- [ ] Agree the required-pass spec set
-- [ ] Golden-file check for at least one PDF and one web source
-- [ ] Write the release checklist
+| Issue | Overlaps |
+|---|---|
+| **#28** Destination tab "Map" buttons have no click handler | **#38** — same dead-wiring class |
+| **#15** Destination tab: move Regenerate, add toast feedback | **#38** — the missing-feedback finding |
+| **#30** Markdown preview shows fields in wrong order | Possibly transform ordering |
+| **#29** Show element type alias on destination block mappings | Standalone |
+| **#16** Restrict doctypes | Standalone |
+| **#19, #20, #23** | Docs screenshot automation |
+| **#31** | AI-assisted source identification |
 
 ---
 
-## Sunday
+## Corrections recorded during planning
 
-### 4. Refresh/regenerate wiring — #38
-
-The largest of the fix items, and the one with confirmed user-visible impact.
-
-- [ ] **Confirm first:** log in `setRefreshHandler` while switching tabs, to
-      verify the single-slot clobber is the real cause. Inferred from code
-      shape, not observed.
-- [ ] Guard the handler null-out
-- [ ] Stop Refresh mutating stored state on the Source view
-- [ ] Surface the discarded `reconciliation` payload; reload Map view after
-      destination regenerate/change
-- [ ] Fix stale area detection on non-PDF re-extract
-- [ ] Decide per dead endpoint: wire up or delete (four of them)
-
-### 5. Two bugs — #42, #43
-
-- [ ] `convertRichTextFields` missing `identifyBy`-matched blocks — check the
-      live project's `map.json` files for `contentTypeKey`-less mappings first,
-      since that determines whether this is live or latent
-- [ ] `markdownToHtml` unescaped fallback paths
-- [ ] **Release R3**
-
-### 6. Typed field design — #44
-
-Design only. No implementation this weekend.
-
-- [ ] Inventory every Umbraco 17 property editor with an explicit decision:
-      mappable / not mappable / deferred
-- [ ] Define the coercion contract per mappable type
-- [ ] Decide parse-failure behaviour
-- [ ] Replace the silent `_ => "text"` fallback with explicit handling
-- [ ] Write to `planning/`, review before any code
-
----
-
-## Monday (contingency, not plan)
-
-Only if Saturday and Sunday overrun. Prefer deferring to next week over
-rushing anything that touches the import path.
-
----
-
-## Deferred to a later release (R4)
-
-Not this weekend. Each needs #40 in place first.
-
-- **#39** — typed-field test fixture. Blocks #34; add typed properties to the
-  existing test site rather than importing the client site (see issue for the
-  reasoning against importing Tailored Travel).
-- **#37** — regex find-and-replace + ReDoS protection. **Prerequisite for #34.**
-- **#41** — extract duplicated apply logic from the two bridge files.
-- **#34** — typed destination fields, integer/date subset of the #44 design.
-
----
-
-## Corrections made during planning
-
-Two working assumptions turned out to be wrong. Both were worth finding before
+Working assumptions that turned out to be wrong. All were found before
 implementation rather than during it.
 
 **1. The #34 brief's premise is false.** It states "the source side works... the
 only blocker is the destination". Find-and-replace is **literal string replace,
 not regex** (`ContentTransformService.cs:690`). The brief's own worked example,
-`(\d{1,2})(st|nd|rd|th)` → `$1`, cannot work — `$1` would be inserted literally.
+`(\d{1,2})(st|nd|rd|th)` → `$1`, cannot work — `$1` is inserted literally.
 **#37 is a prerequisite for #34**, not a parallel improvement.
 
-**2. The apply path is entirely client-side.** The brief's main open question is
-answered: there is no C# write path. The document is created by the frontend
-mutating a scaffold in-browser and POSTing to the Management API. Coercion
-belongs in `#convertRichTextFields`, which is already type-driven.
+**2. The apply path is entirely client-side.** There is no C# write path. The
+document is created by the frontend mutating a scaffold in-browser and POSTing
+to the Management API. Coercion belongs in `#convertRichTextFields`, which is
+already type-driven.
 
-**3. Dependabot alerts are disabled on the UpDoc repository.** Advisory emails
-named UmBootstrap because UpDoc reports nothing at all, despite the
-vulnerabilities being present.
+**3. Dependabot alerts were disabled.** Advisory emails named UmBootstrap
+because UpDoc reported nothing at all, despite the vulnerabilities being
+present.
+
+**4. The vulnerabilities were not docs-only.** Initially scoped as docs-only
+after auditing `docs/`. Enabling Dependabot revealed **10 vulnerabilities in
+the shipped RCL frontend package**, including `pdfjs-dist` — a direct runtime
+dependency that genuinely ships (`dist/pdf.worker.min.mjs`, 1.3MB). Now tracked
+as #51.
+
+---
 
 ## Open questions
 
-- Parse-failure behaviour for typed fields (#44) — abort, skip-and-warn, or
-  block at preview? Recommend abort with a clear error over a silent `null`.
-- Whether #42 is live or latent in the client project — depends on whether any
-  `map.json` there has `identifyBy`-only mappings.
-- Golden files as committed JSON or Playwright snapshots (#40).
+- **Parse-failure behaviour for typed fields (#44)** — abort the import, skip
+  and warn, or block at preview? Recommend abort with a clear error naming
+  field, value and expected type, over a silent `null`.
+- **Is #42 live or latent** in the client project? Depends on whether any
+  `map.json` there has `identifyBy`-only mappings with no `contentTypeKey`.
+- **Is `canvas` reachable in the shipped browser bundle (#51)?** If Vite
+  externalises it, practical severity drops sharply. Needs checking, not
+  assuming.
+- **Golden files as committed JSON or Playwright snapshots (#40)?**
+
+## Housekeeping noted, not urgent
+
+- ~50 remote branches, most from merged work. A prune would make the real state
+  easier to read.
+- Repo integrity checked 2026-07-18: clean, no stashes, all branches in sync.


### PR DESCRIPTION
Planning doc only.

Records what shipped (R1, R2), corrects what was wrong, adds what was missed.

**New since the plan was written:** #51 (RCL advisories), #54 (actions deprecation), and seven pre-existing issues the plan overlooked — two of which (#28, #15) overlap #38 directly.

**Correction:** the plan originally scoped all vulnerabilities as docs-only. Wrong. Enabling Dependabot found 10 in the shipped RCL package including `pdfjs-dist`, a direct runtime dependency that ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)