### PR TITLE
Add running checklist and record R3 in the sprint plan

### DIFF
--- a/planning/SPRINT_2026_07.md
+++ b/planning/SPRINT_2026_07.md
@@ -1,7 +1,7 @@
 # Sprint: July 2026 — UpDoc improvements
 
 Created: 2026-07-18 (Saturday).
-Last updated: 2026-07-18, after shipping R1 and R2.
+Last updated: 2026-07-19, after shipping R1, R2 and R3.
 Target: work ready to adopt Monday morning, 2026-07-20.
 
 ## Context
@@ -39,6 +39,18 @@ lowest-risk-first, not most-interesting-first.
   its own branch allowlist and refused the deploy after a successful build.
   Both changes are needed. GitHub Pages itself needed no change.
 
+### ✅ R3 — documentation and housekeeping (SHIPPED, live)
+
+- **#56** 12 undocumented source files documented. 46 source files, 54 pages,
+  no gaps. Site went 85 → 97 pages.
+- **#57** About tab Source Code link pointed at a repo that does not exist
+  (`DeanLeigh/UpDoc`). Fixed and bundle rebuilt so shipped output carries it.
+- **`.gitattributes` line endings** — Vite writes LF, Git converted to CRLF on
+  checkout, so every rebuild reported ~3 unrelated files as modified. Now zero.
+  Verified with two consecutive rebuilds producing byte-identical output.
+- Repo integrity: clean tree, no stashes, all branches synced, stale local
+  branch removed.
+
 ### ⬜ Remaining
 
 Nothing further is shipped. Everything below is open.
@@ -51,9 +63,10 @@ Nothing further is shipped. Everything below is open.
 |---|---|---|---|
 | **R1 — docs security** | #36 | None | ✅ shipped |
 | **R2 — docs worktree** | #35 | None | ✅ shipped |
-| **R3 — fixes** | #38, #42, #43, and consider #28, #15 | Low, gated by #40 | open |
-| **R4 — features** | #37, #41, #34 | Real | open |
-| **R5 — RCL security** | #51 | Real, ships to consumers | open |
+| **R3 — docs + housekeeping** | #56, #57, gitattributes | None | ✅ shipped |
+| **R4 — fixes** | #38, #42, #43, and consider #28, #15 | Low, gated by #40 | open |
+| **R5 — features** | #37, #41, #34 | Real | open |
+| **R6 — RCL security** | #51 | Real, ships to consumers | open |
 
 Design work (#44) and the actions bump (#54) produce no release of their own.
 
@@ -77,37 +90,83 @@ Everything below depends on this.
 to extract? That is a better canary than an easy one. If nothing springs to
 mind, the Winchester PDF already used in the specs is a fine start.
 
-### Then, in rough order
+### Running checklist
 
-| Issue | What | Notes |
-|---|---|---|
-| **#38** | Refresh/regenerate wiring | Confirmed: Refresh can silently no-op. Consider merging with #28 and #15 — same territory. |
-| **#42** | `convertRichTextFields` misses `identifyBy`-matched blocks | Check the live project's `map.json` first — this may be biting silently already |
-| **#43** | `markdownToHtml` unescaped fallback | Small, self-contained |
-| **#39** | Typed-field test fixture | **Blocks #34** |
-| **#37** | Regex find-and-replace + ReDoS protection | **Prerequisite for #34** |
-| **#41** | Extract duplicated apply logic | Do before #34 so the fix is written once |
-| **#34** | Typed destination fields (integer, date) | Implements the #44 design |
-| **#44** | Design: all typed field mapping | Design only, no implementation |
-| **#51** | RCL security advisories incl. `pdfjs-dist` | Ships to consumers, needs #40 |
-| **#54** | Bump actions off Node 20 | Affects `release.yml`, not just docs. Org-wide. |
+Tick as they ship. Order matters where noted — the dependencies are real.
+
+**Gate — do first**
+
+- [ ] **#40** Release-safety baseline. Everything below depends on it.
+
+**R4 — fixes** (low risk, gated by #40)
+
+- [ ] **#38** Refresh/regenerate wiring — scope with **#28** and **#15**
+- [ ] **#42** `convertRichTextFields` misses `identifyBy`-matched blocks —
+      check the live project's `map.json` first, this may be biting silently.
+      Scope with **#14**.
+- [ ] **#43** `markdownToHtml` unescaped fallback — small, self-contained
+- [ ] **#5** Duplicate key exception with multiple areas — triage early, this
+      is a hard failure
+
+**R5 — features** (real risk, strict order)
+
+- [ ] **#44** Design: all typed field mapping — *design only, no code*
+- [ ] **#39** Typed-field test fixture — **blocks #34**
+- [ ] **#37** Regex find-and-replace + ReDoS — **prerequisite for #34**
+- [ ] **#41** Extract duplicated apply logic — before #34, so the fix is
+      written once rather than twice
+- [ ] **#34** Typed destination fields — implements the #44 design
+
+**R6 — RCL security**
+
+- [ ] **#51** `pdfjs-dist` and the shipped frontend package. Ships to
+      consumers, needs #40.
+
+**Not release-bound**
+
+- [ ] **#54** Bump actions off Node 20 — affects `release.yml`, org-wide.
+      Do alone, not alongside other workflow changes.
 
 ---
 
 ## Pre-existing issues not originally in this sprint
 
-These predate the sprint and were missed when it was first written. Two overlap
-directly with #38 and should be considered alongside it rather than separately:
+25 issues are open. The sprint covers 11 of them. The rest predate it and were
+missed when it was first written — listed here so the backlog is visible rather
+than forgotten.
+
+**Overlaps with sprint work — scope these together, not separately:**
 
 | Issue | Overlaps |
 |---|---|
 | **#28** Destination tab "Map" buttons have no click handler | **#38** — same dead-wiring class |
 | **#15** Destination tab: move Regenerate, add toast feedback | **#38** — the missing-feedback finding |
-| **#30** Markdown preview shows fields in wrong order | Possibly transform ordering |
-| **#29** Show element type alias on destination block mappings | Standalone |
-| **#16** Restrict doctypes | Standalone |
-| **#19, #20, #23** | Docs screenshot automation |
+| **#14** Map should resolve by StableKey, not section ID | **#42** — both are mapping-resolution bugs |
+
+**Standalone bugs:**
+
+| Issue | What |
+|---|---|
+| **#5** | `ContentTransformService` duplicate key exception with multiple areas |
+| **#7** | Empty web-source metadata fields in PDF extraction JSON |
+| **#8** | No warning when a referenced blueprint is deleted |
+| **#9** | Content preview tabs in different order than document |
+| **#30** | Markdown preview shows fields in wrong order |
+
+Note **#9 and #30 are both ordering bugs** in preview surfaces and may share a
+cause. Worth checking together.
+
+**#5 is worth triaging early** — a duplicate key exception is a hard failure,
+not a cosmetic issue, and multiple areas is a normal configuration.
+
+**Enhancements, not scheduled:**
+
+| Issue | What |
+|---|---|
+| **#16** | Restrict doctypes |
+| **#29** | Show element type alias on destination block mappings |
 | **#31** | AI-assisted source identification |
+| **#19, #20, #23** | Docs screenshot automation |
 
 ---
 


### PR DESCRIPTION
Planning doc only.

Converts the task ordering into tickable checkboxes, records R3 as shipped, and expands the backlog section — 25 issues are open, the sprint covered 11, the rest were invisible in the plan.

Three overlaps now flagged so they get scoped together rather than fixed twice:
- #28 and #15 with #38 (Destination tab wiring)
- #14 with #42 (mapping resolution)
- #9 and #30 may share a cause (preview ordering)

#5 pulled into the fixes release — a duplicate key exception with multiple areas is a hard failure, and multiple areas is a normal configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)