### PR TITLE
Record R4 and live import verification in the sprint plan

### DIFF
--- a/planning/SPRINT_2026_07.md
+++ b/planning/SPRINT_2026_07.md
@@ -1,7 +1,7 @@
 # Sprint: July 2026 — UpDoc improvements
 
 Created: 2026-07-18 (Saturday).
-Last updated: 2026-07-19, after shipping R1, R2 and R3.
+Last updated: 2026-07-19, after shipping R1-R4.
 Target: work ready to adopt Monday morning, 2026-07-20.
 
 ## Context
@@ -51,6 +51,46 @@ lowest-risk-first, not most-interesting-first.
 - Repo integrity: clean tree, no stashes, all branches synced, stale local
   branch removed.
 
+### ✅ R4 — transform crash (SHIPPED)
+
+**#5** `ContentTransformService` threw whenever two areas on a page shared a
+name. Four months old. Reproduced live, fixed, verified.
+
+The issue's own diagnosis was wrong, which is why it survived. Its repro steps
+say "define two or more areas" with no mention of naming — because naming was
+never the trigger. Areas auto-name in the editor, so this looked unreachable.
+The real cause was **geometrically detected areas having no name at all**
+(`PdfPagePropertiesService.cs:501` set none, unlike the template path at
+`:282`), producing several areas named `""` on one page.
+
+Worse than it looked: area detection saves *before* the transform runs, so a
+failure left the workflow half-updated with nothing in the UI to say so. The
+exception appeared only in the server console.
+
+Three changes, commit `531829c`:
+1. Geometric areas numbered per page — the cause
+2. Sort-order lookup tolerates duplicates, warns via `TransformDiagnostics`
+3. Area editor warns inline on duplicate names
+
+**Found on the way:** renaming an area silently orphans its rules, which are
+keyed by kebab-cased name. `tailoredTourPdf` already carries a stale `test`
+key — that is what an orphaned rule set looks like. Raised as **#62**.
+
+### Live import verification (2026-07-19)
+
+Both source types confirmed working end to end against real content before any
+code changes:
+
+- **Web** — a live Tailored Travel tour page. Title, description, itinerary,
+  features, accommodation, sights all populated. No raw markdown.
+- **PDF** — Flemish Masters. All five day headings correct, lists correct,
+  hyperlink preserved, organiser block list populated.
+
+**One defect found:** web headings marked up as `<p><strong>` split across two
+`<strong>` tags do not become `<h3>`. Single-`<strong>` paragraphs do. Likely a
+bold-detection condition rather than a code bug. Not yet raised — belongs with
+the transform work.
+
 ### ⬜ Remaining
 
 Nothing further is shipped. Everything below is open.
@@ -64,9 +104,11 @@ Nothing further is shipped. Everything below is open.
 | **R1 — docs security** | #36 | None | ✅ shipped |
 | **R2 — docs worktree** | #35 | None | ✅ shipped |
 | **R3 — docs + housekeeping** | #56, #57, gitattributes | None | ✅ shipped |
-| **R4 — fixes** | #38, #42, #43, and consider #28, #15 | Low, gated by #40 | open |
-| **R5 — features** | #37, #41, #34 | Real | open |
-| **R6 — RCL security** | #51 | Real, ships to consumers | open |
+| **R4 — transform crash** | #5 | Low, verified live | ✅ shipped |
+| **R5 — fixes** | #38, #42, #43, and consider #28, #15 | Low, gated by #40 | open |
+| **R6 — features** | #37, #41, #34 | Real | open |
+| **R7 — identity** | #62, #14 | **Breaking without care** | open |
+| **R8 — RCL security** | #51 | Real, ships to consumers | open |
 
 Design work (#44) and the actions bump (#54) produce no release of their own.
 
@@ -86,9 +128,25 @@ Two parts:
 
 Everything below depends on this.
 
+**Scope grew on 2026-07-19.** Originally conceived as golden files from
+existing workflows. It should also cover the **authoring** flow — create
+workflow, draw areas, transform, map, create document. That is where #5 lived,
+and where #38, #28 and #62 all live. R5 and R7 are almost entirely
+authoring-side, so a baseline that only covers content creation would miss
+what we are about to change.
+
+The #5 session showed why: the bug was only found by creating a throwaway
+workflow and watching files on disk. A baseline should make that repeatable.
+
+**#62 cannot proceed without this.** Its migration re-keys `areaRules` for both
+existing workflows, and the failure mode is silent degradation rather than a
+crash. Before/after transform output is the only way to prove it worked.
+
 **Open question for Dean:** is there a PDF that has historically been awkward
 to extract? That is a better canary than an easy one. If nothing springs to
-mind, the Winchester PDF already used in the specs is a fine start.
+mind, the Winchester PDF already used in the specs is a fine start — though the
+Flemish Masters PDF is now well understood, having been imported and inspected
+end to end.
 
 ### Running checklist
 
@@ -98,17 +156,22 @@ Tick as they ship. Order matters where noted — the dependencies are real.
 
 - [ ] **#40** Release-safety baseline. Everything below depends on it.
 
-**R4 — fixes** (low risk, gated by #40)
+**R5 — fixes** (low risk, gated by #40)
 
-- [ ] **#38** Refresh/regenerate wiring — scope with **#28** and **#15**
+- [x] **#5** Duplicate key exception with multiple areas — shipped, verified
+      live. Cause was unnamed geometric areas, not duplicate naming.
+- [ ] **#38** Refresh/regenerate wiring — scope with **#28** and **#15**.
+      Note: Refresh **does** fire on the Source tab (confirmed 2026-07-19 —
+      it triggered area detection). The single-slot clobber theory still needs
+      testing on tab switch specifically.
 - [ ] **#42** `convertRichTextFields` misses `identifyBy`-matched blocks —
       check the live project's `map.json` first, this may be biting silently.
       Scope with **#14**.
 - [ ] **#43** `markdownToHtml` unescaped fallback — small, self-contained
-- [ ] **#5** Duplicate key exception with multiple areas — triage early, this
-      is a hard failure
+- [ ] Web headings using split `<strong>` tags do not become `<h3>` — found
+      2026-07-19, not yet raised. Likely a bold-detection condition.
 
-**R5 — features** (real risk, strict order)
+**R6 — features** (real risk, strict order)
 
 - [ ] **#44** Design: all typed field mapping — *design only, no code*
 - [ ] **#39** Typed-field test fixture — **blocks #34**
@@ -117,7 +180,16 @@ Tick as they ship. Order matters where noted — the dependencies are real.
       written once rather than twice
 - [ ] **#34** Typed destination fields — implements the #44 design
 
-**R6 — RCL security**
+**R7 — area and section identity** (breaking without care)
+
+- [ ] **#62** Stable IDs for areas. Renaming an area currently orphans its
+      rules, silently — they are keyed by kebab-cased name. Migration must
+      re-key `areaRules` for both existing workflows; getting it wrong
+      degrades output without erroring. **Gated on #40.**
+- [ ] **#14** Map should resolve by StableKey — same class of problem at
+      section level. Design with #62.
+
+**R8 — RCL security**
 
 - [ ] **#51** `pdfjs-dist` and the shipped frontend package. Ships to
       consumers, needs #40.


### PR DESCRIPTION
Planning doc only.

Ships #5 as R4, renumbers remaining releases, adds R7 for the identity work (#62, #14).

Records what live testing established: both source types verified end to end, one new defect found (web split-`<strong>` headings), and #38's diagnosis narrowed — Refresh *does* fire on the Source tab, so the silent no-op theory needs testing on tab switch specifically.

Expands #40 to cover the authoring flow, not just content creation. That is where #5 lived and where #38, #28 and #62 all live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)