### PR TITLE
Upgrade AngleSharp and AngleSharp.Css

### DIFF
--- a/src/UpDoc/UpDoc.csproj
+++ b/src/UpDoc/UpDoc.csproj
@@ -52,7 +52,7 @@
          17.5.3 declares MailKit 4.16.0, which requires MimeKit >= 4.16.0, so the pin
          became a downgrade and failed the restore with NU1605. -->
     <PackageReference Include="AngleSharp" Version="1.5.2" />
-    <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.154" />
+    <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.222" />
     <PackageReference Include="PdfPig" Version="0.1.13" />
     <PackageReference Include="Umbraco.Cms.Web.Common" Version="17.5.3" />
     <PackageReference Include="Umbraco.Cms.Api.Common" Version="17.5.3" />

--- a/src/UpDoc/UpDoc.csproj
+++ b/src/UpDoc/UpDoc.csproj
@@ -51,7 +51,7 @@
          Umbraco 17.2.2's Web.Common resolved MimeKit 4.14.0 transitively. Web.Common
          17.5.3 declares MailKit 4.16.0, which requires MimeKit >= 4.16.0, so the pin
          became a downgrade and failed the restore with NU1605. -->
-    <PackageReference Include="AngleSharp" Version="1.4.0" />
+    <PackageReference Include="AngleSharp" Version="1.5.2" />
     <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.154" />
     <PackageReference Include="PdfPig" Version="0.1.13" />
     <PackageReference Include="Umbraco.Cms.Web.Common" Version="17.5.3" />


### PR DESCRIPTION
Closes #69

| Package | From | To |
|---|---|---|
| AngleSharp | 1.4.0 | **1.5.2** |
| AngleSharp.Css | 1.0.0-beta.154 | **1.0.0-beta.222** |

Both are direct RCL dependencies and ship to every consumer.

## AngleSharp — clears a moderate advisory

[GHSA-pgww-w46g-26qg](https://github.com/advisories/GHSA-pgww-w46g-26qg). Low risk: 1.5.2 declares the same single dependency as 1.4.0.

`dotnet list package --vulnerable` no longer reports AngleSharp. Build warnings dropped from 20 to 6.

## AngleSharp.Css — 68 betas behind, and the order mattered

There is **no stable release** of AngleSharp.Css; the whole line is betas, so one ships inside the package either way. This makes it a current one.

The ordering was necessary, not tidy: **beta.222 requires `AngleSharp [1.5.0, 2.0.0)`**, where beta.154 accepted `[1.0.0, 2.0.0)`. The `.Css` bump was only possible because AngleSharp went to 1.5.2 first.

Higher risk than the main package — AngleSharp.Css provides the computed CSS that web extraction depends on (font size, colour, weight), feeding bold detection and the transform rules. A change in computed values would alter output without erroring.

## Verified with a live web import

The Suffolk page through `groupTourWebPage`, compared field by field against the known-good in `planning/DEPENDENCIES.md`. **Byte-identical.**

- Itinerary 5 days, same prose
- Features 6 items, Sights 11 items, accommodation paragraph
- **Day 1 renders as `<p>` and Days 2-5 as `<h3>`, exactly as before**

That last point is the meaningful one. The Day 1 boundary depends on computed font weight from AngleSharp.Css — the known pre-existing defect from split `<strong>` tags. If the CSS engine had changed behaviour across 68 betas, that is precisely where it would show. It did not move.

Two commits, so a regression would have been attributable to one package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)