### PR TITLE
Allow four-part version tags to trigger a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,18 @@ name: Release to NuGet
 on:
   push:
     tags:
+      # UpDoc versions track the Umbraco version they target, so the first three
+      # parts are the CMS version. The fourth is UpDoc's own build number on that
+      # CMS, which is what allows more than one UpDoc release per Umbraco patch.
+      #
+      #   17.5.3      first UpDoc release targeting Umbraco 17.5.3
+      #   17.5.3.1    a later UpDoc release, same CMS
+      #   17.5.3-rc1  prerelease
+      #
+      # Note NuGet normalises a trailing zero, so 17.5.3.0 publishes as 17.5.3.
+      # Start the fourth part at 1.
       - '[0-9]*.[0-9]*.[0-9]*'
+      - '[0-9]*.[0-9]*.[0-9]*.[0-9]*'
       - '[0-9]*.[0-9]*.[0-9]*-*'
   workflow_dispatch:
 


### PR DESCRIPTION
UpDoc versions track the Umbraco version they target, so the first three parts are the CMS version. That leaves no room for a second UpDoc release on an unchanged Umbraco.

The fourth part is UpDoc's own build number on that CMS:

```
17.5.3      first UpDoc release targeting Umbraco 17.5.3
17.5.3.1    a later UpDoc release, same CMS
```

**Only the trigger changed.** The NuGet Trusted Publishing steps are untouched.

**Verified, not assumed:** `dotnet pack -p:Version=17.5.3.1` produces `Umbraco.Community.UpDoc.17.5.3.1.nupkg`.

Two pack warnings noted while testing, **neither introduced by this change**:

- **NU5104** — stable release with a prerelease dependency. `AngleSharp.Css` has no stable 1.x; `17.2.2` shipped with the same warning. Parked in #73.
- **NU5119** — `.env` excluded. Correct, it holds Playwright credentials.

Also: NuGet normalises a trailing zero, so `17.5.3.0` would publish as `17.5.3`. Start the fourth part at 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)