### PR TITLE
Rename Itinerary element type to match Tailored Travel

### DIFF
--- a/src/UpDoc.TestSite/Views/Partials/blockgrid/Components/featureRichTextEditorItinerary.cshtml
+++ b/src/UpDoc.TestSite/Views/Partials/blockgrid/Components/featureRichTextEditorItinerary.cshtml
@@ -1,0 +1,7 @@
+﻿@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<Umbraco.Cms.Core.Models.Blocks.BlockGridItem<FeatureRichTextEditorItinerary, FeatureSettings>>
+
+@{
+    Layout = "_Layout_Features.cshtml";
+}
+
+@Model.Content.RichTextContent

--- a/src/UpDoc.TestSite/Views/Partials/blockgrid/Components/featureRichTextEditorItinery.cshtml
+++ b/src/UpDoc.TestSite/Views/Partials/blockgrid/Components/featureRichTextEditorItinery.cshtml
@@ -1,7 +1,0 @@
-﻿@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<Umbraco.Cms.Core.Models.Blocks.BlockGridItem<FeatureRichTextEditorItinery, FeatureSettings>>
-
-@{
-    Layout = "_Layout_Features.cshtml";
-}
-
-@Model.Content.RichTextContent

--- a/src/UpDoc.TestSite/uSync/v17/Blueprints/group-tour-blueprint.config
+++ b/src/UpDoc.TestSite/uSync/v17/Blueprints/group-tour-blueprint.config
@@ -51,7 +51,7 @@
       ]
     },
     {
-      "contentTypeKey": "365fd365-6ec4-4fbb-9434-1df366aa77f8",
+      "contentTypeKey": "837beecf-4239-4b3d-b683-1d611af3da2e",
       "key": "a1b2c3d4-7777-4aaa-b777-777777777777",
       "values": [
         {

--- a/src/UpDoc.TestSite/uSync/v17/Blueprints/tailored-tour-blueprint.config
+++ b/src/UpDoc.TestSite/uSync/v17/Blueprints/tailored-tour-blueprint.config
@@ -33,7 +33,7 @@
       "values": []
     },
     {
-      "contentTypeKey": "365fd365-6ec4-4fbb-9434-1df366aa77f8",
+      "contentTypeKey": "837beecf-4239-4b3d-b683-1d611af3da2e",
       "key": "6032afd9-a533-40aa-b4de-ac8ae5236ca1",
       "values": [
         {

--- a/src/UpDoc.TestSite/uSync/v17/Content/flemish-masters-bruges-antwerp-and-ghent.config
+++ b/src/UpDoc.TestSite/uSync/v17/Content/flemish-masters-bruges-antwerp-and-ghent.config
@@ -32,7 +32,7 @@
       "values": []
     },
     {
-      "contentTypeKey": "365fd365-6ec4-4fbb-9434-1df366aa77f8",
+      "contentTypeKey": "837beecf-4239-4b3d-b683-1d611af3da2e",
       "key": "5722787e-afd2-42ef-9646-c30de90359c9",
       "values": [
         {

--- a/src/UpDoc.TestSite/uSync/v17/Content/group-tour-template.config
+++ b/src/UpDoc.TestSite/uSync/v17/Content/group-tour-template.config
@@ -50,7 +50,7 @@
       ]
     },
     {
-      "contentTypeKey": "365fd365-6ec4-4fbb-9434-1df366aa77f8",
+      "contentTypeKey": "837beecf-4239-4b3d-b683-1d611af3da2e",
       "key": "a1b2c3d4-7777-4aaa-b777-777777777777",
       "values": [
         {

--- a/src/UpDoc.TestSite/uSync/v17/Content/istanbul-where-east-meets-west-1.config
+++ b/src/UpDoc.TestSite/uSync/v17/Content/istanbul-where-east-meets-west-1.config
@@ -32,7 +32,7 @@
       "values": []
     },
     {
-      "contentTypeKey": "365fd365-6ec4-4fbb-9434-1df366aa77f8",
+      "contentTypeKey": "837beecf-4239-4b3d-b683-1d611af3da2e",
       "key": "3317ff13-82e3-4b7a-9f68-e9b431079051",
       "values": [
         {

--- a/src/UpDoc.TestSite/uSync/v17/Content/istanbul-where-east-meets-west-1_2sxmnnom.config
+++ b/src/UpDoc.TestSite/uSync/v17/Content/istanbul-where-east-meets-west-1_2sxmnnom.config
@@ -32,7 +32,7 @@
       "values": []
     },
     {
-      "contentTypeKey": "365fd365-6ec4-4fbb-9434-1df366aa77f8",
+      "contentTypeKey": "837beecf-4239-4b3d-b683-1d611af3da2e",
       "key": "6f370db0-9f86-4ae2-b452-1b8e51d3be42",
       "values": [
         {

--- a/src/UpDoc.TestSite/uSync/v17/Content/istanbul-where-east-meets-west-2.config
+++ b/src/UpDoc.TestSite/uSync/v17/Content/istanbul-where-east-meets-west-2.config
@@ -32,7 +32,7 @@
       "values": []
     },
     {
-      "contentTypeKey": "365fd365-6ec4-4fbb-9434-1df366aa77f8",
+      "contentTypeKey": "837beecf-4239-4b3d-b683-1d611af3da2e",
       "key": "44714196-9d08-4a8a-bec0-40f0fd53febd",
       "values": [
         {

--- a/src/UpDoc.TestSite/uSync/v17/Content/istanbul-where-east-meets-west.config
+++ b/src/UpDoc.TestSite/uSync/v17/Content/istanbul-where-east-meets-west.config
@@ -32,7 +32,7 @@
       "values": []
     },
     {
-      "contentTypeKey": "365fd365-6ec4-4fbb-9434-1df366aa77f8",
+      "contentTypeKey": "837beecf-4239-4b3d-b683-1d611af3da2e",
       "key": "ca87dfe2-f63d-4383-b731-88a7e5735497",
       "values": [
         {

--- a/src/UpDoc.TestSite/uSync/v17/Content/tailored-tour-template.config
+++ b/src/UpDoc.TestSite/uSync/v17/Content/tailored-tour-template.config
@@ -32,7 +32,7 @@
       "values": []
     },
     {
-      "contentTypeKey": "365fd365-6ec4-4fbb-9434-1df366aa77f8",
+      "contentTypeKey": "837beecf-4239-4b3d-b683-1d611af3da2e",
       "key": "6032afd9-a533-40aa-b4de-ac8ae5236ca1",
       "values": [
         {

--- a/src/UpDoc.TestSite/uSync/v17/Content/the-art-of-tuscany-and-umbria.config
+++ b/src/UpDoc.TestSite/uSync/v17/Content/the-art-of-tuscany-and-umbria.config
@@ -50,7 +50,7 @@
       ]
     },
     {
-      "contentTypeKey": "365fd365-6ec4-4fbb-9434-1df366aa77f8",
+      "contentTypeKey": "837beecf-4239-4b3d-b683-1d611af3da2e",
       "key": "16d7f42b-3804-4ae0-a266-577ae247410c",
       "values": [
         {

--- a/src/UpDoc.TestSite/uSync/v17/Content/the-art-of-tuscany-umbria.config
+++ b/src/UpDoc.TestSite/uSync/v17/Content/the-art-of-tuscany-umbria.config
@@ -32,7 +32,7 @@
       "values": []
     },
     {
-      "contentTypeKey": "365fd365-6ec4-4fbb-9434-1df366aa77f8",
+      "contentTypeKey": "837beecf-4239-4b3d-b683-1d611af3da2e",
       "key": "daeb8be1-a40f-4207-a2b5-08ca87bafefb",
       "values": [
         {

--- a/src/UpDoc.TestSite/uSync/v17/Content/the-castles-and-gardens-of-kent.config
+++ b/src/UpDoc.TestSite/uSync/v17/Content/the-castles-and-gardens-of-kent.config
@@ -22,7 +22,7 @@
       "values": []
     },
     {
-      "contentTypeKey": "365fd365-6ec4-4fbb-9434-1df366aa77f8",
+      "contentTypeKey": "837beecf-4239-4b3d-b683-1d611af3da2e",
       "key": "e9ccdedc-9fe8-43b8-b4ab-ca8fe1e7a9ac",
       "values": [
         {

--- a/src/UpDoc.TestSite/uSync/v17/ContentTypes/featurerichtexteditoritinerary.config
+++ b/src/UpDoc.TestSite/uSync/v17/ContentTypes/featurerichtexteditoritinerary.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<ContentType Key="365fd365-6ec4-4fbb-9434-1df366aa77f8" Alias="featureRichTextEditorItinery" Level="2">
+<ContentType Key="837beecf-4239-4b3d-b683-1d611af3da2e" Alias="featureRichTextEditorItinerary" Level="2">
   <Info>
-    <Name>Rich Text Editor - Itinery</Name>
+    <Name>Rich Text Editor - Itinerary</Name>
     <Icon>icon-newspaper color-black</Icon>
     <Thumbnail>folder.png</Thumbnail>
     <Description></Description>

--- a/src/UpDoc.TestSite/uSync/v17/DataTypes/BlockGridGroupTour.config
+++ b/src/UpDoc.TestSite/uSync/v17/DataTypes/BlockGridGroupTour.config
@@ -260,7 +260,7 @@
       "thumbnail": "/App_Plugins/icons/Thumbnails-Icons-RTE.svg"
     },
     {
-      "contentElementTypeKey": "365fd365-6ec4-4fbb-9434-1df366aa77f8",
+      "contentElementTypeKey": "837beecf-4239-4b3d-b683-1d611af3da2e",
       "allowAtRoot": false,
       "allowInAreas": true,
       "groupKey": "ec39ec1f-61b5-40ba-bc55-16b455d31945",

--- a/src/UpDoc.TestSite/uSync/v17/DataTypes/BlockGridTailoredTour.config
+++ b/src/UpDoc.TestSite/uSync/v17/DataTypes/BlockGridTailoredTour.config
@@ -260,7 +260,7 @@
       "thumbnail": "/App_Plugins/icons/Thumbnails-Icons-RTE.svg"
     },
     {
-      "contentElementTypeKey": "365fd365-6ec4-4fbb-9434-1df366aa77f8",
+      "contentElementTypeKey": "837beecf-4239-4b3d-b683-1d611af3da2e",
       "allowAtRoot": false,
       "allowInAreas": true,
       "groupKey": "ec39ec1f-61b5-40ba-bc55-16b455d31945",

--- a/src/UpDoc.TestSite/umbraco/models/FeatureRichTextEditorItinerary.generated.cs
+++ b/src/UpDoc.TestSite/umbraco/models/FeatureRichTextEditorItinerary.generated.cs
@@ -18,14 +18,14 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Web.Common.PublishedModels
 {
-	/// <summary>Rich Text Editor - Itinery</summary>
-	[PublishedModel("featureRichTextEditorItinery")]
-	public partial class FeatureRichTextEditorItinery : PublishedElementModel, IFeatureComponentFeatureDescription, IFeatureComponentFeatureSummary, IFeatureComponentFeatureTitle, IFeatureComponentRichTextEditor
+	/// <summary>Rich Text Editor - Itinerary</summary>
+	[PublishedModel("featureRichTextEditorItinerary")]
+	public partial class FeatureRichTextEditorItinerary : PublishedElementModel, IFeatureComponentFeatureDescription, IFeatureComponentFeatureSummary, IFeatureComponentFeatureTitle, IFeatureComponentRichTextEditor
 	{
 		// helpers
 #pragma warning disable 0109 // new is redundant
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "17.5.3+a9649da")]
-		public new const string ModelTypeAlias = "featureRichTextEditorItinery";
+		public new const string ModelTypeAlias = "featureRichTextEditorItinerary";
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "17.5.3+a9649da")]
 		public new const PublishedItemType ModelItemType = PublishedItemType.Content;
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "17.5.3+a9649da")]
@@ -34,14 +34,14 @@ namespace Umbraco.Cms.Web.Common.PublishedModels
 			=> PublishedModelUtility.GetModelContentType(contentTypeCache, ModelItemType, ModelTypeAlias);
 		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "17.5.3+a9649da")]
 		[return: global::System.Diagnostics.CodeAnalysis.MaybeNull]
-		public static IPublishedPropertyType GetModelPropertyType<TValue>(IPublishedContentTypeCache contentTypeCache, Expression<Func<FeatureRichTextEditorItinery, TValue>> selector)
+		public static IPublishedPropertyType GetModelPropertyType<TValue>(IPublishedContentTypeCache contentTypeCache, Expression<Func<FeatureRichTextEditorItinerary, TValue>> selector)
 			=> PublishedModelUtility.GetModelPropertyType(GetModelContentType(contentTypeCache), selector);
 #pragma warning restore 0109
 
 		private IPublishedValueFallback _publishedValueFallback;
 
 		// ctor
-		public FeatureRichTextEditorItinery(IPublishedElement content, IPublishedValueFallback publishedValueFallback)
+		public FeatureRichTextEditorItinerary(IPublishedElement content, IPublishedValueFallback publishedValueFallback)
 			: base(content, publishedValueFallback)
 		{
 			_publishedValueFallback = publishedValueFallback;

--- a/src/UpDoc.TestSite/updoc/workflows/groupTourWebPage/destination/destination.json
+++ b/src/UpDoc.TestSite/updoc/workflows/groupTourWebPage/destination/destination.json
@@ -95,8 +95,8 @@
         },
         {
           "key": "a1b2c3d4-7777-4aaa-b777-777777777777",
-          "contentTypeAlias": "featureRichTextEditorItinery",
-          "contentTypeKey": "365fd365-6ec4-4fbb-9434-1df366aa77f8",
+          "contentTypeAlias": "featureRichTextEditorItinerary",
+          "contentTypeKey": "837beecf-4239-4b3d-b683-1d611af3da2e",
           "label": "Itinerary",
           "description": null,
           "identifyBy": {

--- a/src/UpDoc.TestSite/updoc/workflows/groupTourWebPage/map/map.json
+++ b/src/UpDoc.TestSite/updoc/workflows/groupTourWebPage/map/map.json
@@ -45,7 +45,7 @@
         {
           "target": "richTextContent",
           "blockKey": "a1b2c3d4-7777-4aaa-b777-777777777777",
-          "contentTypeKey": "365fd365-6ec4-4fbb-9434-1df366aa77f8",
+          "contentTypeKey": "837beecf-4239-4b3d-b683-1d611af3da2e",
           "transforms": null
         }
       ],

--- a/src/UpDoc.TestSite/updoc/workflows/tailoredTourPdf/destination/destination.json
+++ b/src/UpDoc.TestSite/updoc/workflows/tailoredTourPdf/destination/destination.json
@@ -131,8 +131,8 @@
         },
         {
           "key": "6032afd9-a533-40aa-b4de-ac8ae5236ca1",
-          "contentTypeAlias": "featureRichTextEditorItinery",
-          "contentTypeKey": "365fd365-6ec4-4fbb-9434-1df366aa77f8",
+          "contentTypeAlias": "featureRichTextEditorItinerary",
+          "contentTypeKey": "837beecf-4239-4b3d-b683-1d611af3da2e",
           "label": "Itinerary",
           "description": null,
           "identifyBy": {

--- a/src/UpDoc.TestSite/updoc/workflows/tailoredTourPdf/map/map.json
+++ b/src/UpDoc.TestSite/updoc/workflows/tailoredTourPdf/map/map.json
@@ -171,7 +171,7 @@
         {
           "target": "richTextContent",
           "blockKey": "6032afd9-a533-40aa-b4de-ac8ae5236ca1",
-          "contentTypeKey": "365fd365-6ec4-4fbb-9434-1df366aa77f8",
+          "contentTypeKey": "837beecf-4239-4b3d-b683-1d611af3da2e",
           "transforms": null
         }
       ],
@@ -185,7 +185,7 @@
         {
           "target": "featurePropertyFeatureSummary",
           "blockKey": "6032afd9-a533-40aa-b4de-ac8ae5236ca1",
-          "contentTypeKey": "365fd365-6ec4-4fbb-9434-1df366aa77f8",
+          "contentTypeKey": "837beecf-4239-4b3d-b683-1d611af3da2e",
           "transforms": null
         }
       ],

--- a/src/UpDoc.TestSite/updoc/workflows/tailoredTourTestPdf/destination/destination.json
+++ b/src/UpDoc.TestSite/updoc/workflows/tailoredTourTestPdf/destination/destination.json
@@ -95,8 +95,8 @@
         },
         {
           "key": "6032afd9-a533-40aa-b4de-ac8ae5236ca1",
-          "contentTypeAlias": "featureRichTextEditorItinery",
-          "contentTypeKey": "365fd365-6ec4-4fbb-9434-1df366aa77f8",
+          "contentTypeAlias": "featureRichTextEditorItinerary",
+          "contentTypeKey": "837beecf-4239-4b3d-b683-1d611af3da2e",
           "label": "Itinerary",
           "description": null,
           "identifyBy": {


### PR DESCRIPTION
Renames the test site's itinerary element type so it matches Tailored Travel.

| | Before | After |
|---|---|---|
| Key | `365fd365-6ec4-4fbb-9434-1df366aa77f8` | `837beecf-4239-4b3d-b683-1d611af3da2e` |
| Alias | `featureRichTextEditorItinery` | `featureRichTextEditorItinerary` |
| Name | Rich Text Editor - Itinery | Rich Text Editor - Itinerary |

### Why adopt Tailored Travel's key rather than just fix the spelling

The #110 audit found **all 61 content types shared between the two sites have identical keys**. The test site was built from Tailored Travel's uSync export and keys were preserved throughout. This type was the single exception.

Keeping the old key would have left one isolated break in an otherwise complete alignment.

### Approach

A file-level find and replace in one commit rather than a backoffice content migration.

Block instances bind to their element type **by key**, so a partial rename orphans their content. Replacing every reference together means the graph is never half-renamed. 21 key occurrences across 20 files, plus 4 alias occurrences, all verified against the audit before and after.

### The second commit

The block grid resolves partial views **by element type alias**. After the rename Umbraco looked for `blockgrid/Components/featureRichTextEditorItinerary` and could not find it, so tour pages rendered "Could not render component of type" where the itinerary should be.

The original audit covered uSync configs and UpDoc workflow JSON but not `Views/`, which is why this was missed on the first pass. Caught by checking a real page rather than trusting the import report.

Umbraco regenerated the correct model class during the uSync import, so the stale `FeatureRichTextEditorItinery.generated.cs` is removed rather than renamed.

### Verification

uSync import ran clean: 4 DataTypes, 2 Content Types, 9 Content.

All four tour pages checked after a restart, with itinerary content intact and no render errors:

- Istanbul – where East meets West
- Flemish Masters – Bruges, Antwerp and Ghent
- The Art of Tuscany and Umbria
- The Castles and Gardens of Kent

Day 1 through Day 4 present with full body text on each.

**E2E specs could not be used to verify this.** They fail on an unrelated pre-existing problem: the Management API token is no longer readable from `localStorage` on Umbraco 17.5.3. Raised separately as #112.

### Notes

The icon is left as-is. Tailored Travel uses `icon-newspaper` where the test site has `icon-newspaper color-black`. Cosmetic and out of scope here, noted for #110.

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)
