### PR TITLE
Get the E2E auth token from the backoffice, not localStorage

### DIFF
--- a/src/UpDoc/wwwroot/App_Plugins/UpDoc/tests/e2e/auth-token.ts
+++ b/src/UpDoc/wwwroot/App_Plugins/UpDoc/tests/e2e/auth-token.ts
@@ -1,0 +1,61 @@
+import { Page } from '@playwright/test';
+
+/**
+ * Fetches a Management API bearer token from the running backoffice.
+ *
+ * Umbraco 17.5.3 does not expose the token to scripts. `HideBackOfficeTokensHandler`
+ * encrypts it into HTTP-only cookies, so `localStorage.getItem('umb:userAuthTokenResponse')`
+ * returns null and a cookie-only `fetch` gets a 401: the Management API wants a bearer
+ * token in the header, and cookies are only the refresh credential.
+ *
+ * The supported route is to ask the backoffice's own auth context. That means raising a
+ * `umb:context-request` event, which is how every backoffice element resolves a context.
+ * The event carries its properties directly rather than in `detail`, and `apiAlias`
+ * defaults to `'default'`.
+ *
+ * Call this once per test and reuse the token. It requires a page already on `/umbraco`
+ * with the backoffice booted.
+ */
+export async function getManagementApiToken(page: Page): Promise<string> {
+	const token = await page.evaluate(async () => {
+		return new Promise<string>((resolve, reject) => {
+			let settled = false;
+			const timer = setTimeout(() => {
+				if (!settled) reject(new Error('Timed out waiting for UmbAuthContext'));
+			}, 15000);
+
+			const event: any = new Event('umb:context-request', {
+				bubbles: true,
+				composed: true,
+				cancelable: true,
+			});
+			event.contextAlias = 'UmbAuthContext';
+			event.apiAlias = 'default';
+			event.stopAtContextMatch = true;
+			event.callback = (context: any) => {
+				if (settled) return true;
+				settled = true;
+				clearTimeout(timer);
+				Promise.resolve(context.getLatestToken()).then(resolve).catch(reject);
+				return true;
+			};
+
+			(document.querySelector('umb-app') || document.body).dispatchEvent(event);
+		});
+	});
+
+	if (!token) throw new Error('UmbAuthContext returned an empty token');
+	return token;
+}
+
+/**
+ * Ensures the page is on the backoffice and its auth context is available, then returns
+ * a token. Use when a spec has not already navigated to `/umbraco`.
+ */
+export async function ensureBackofficeToken(page: Page): Promise<string> {
+	if (!page.url().includes('/umbraco')) {
+		await page.goto('/umbraco');
+	}
+	await page.waitForFunction(() => !!document.querySelector('umb-app'), null, { timeout: 30000 });
+	return getManagementApiToken(page);
+}

--- a/src/UpDoc/wwwroot/App_Plugins/UpDoc/tests/e2e/blockkey-reconciliation.spec.ts
+++ b/src/UpDoc/wwwroot/App_Plugins/UpDoc/tests/e2e/blockkey-reconciliation.spec.ts
@@ -1,5 +1,6 @@
 import { expect, Page } from '@playwright/test';
 import { ConstantHelper, test } from '@umbraco/playwright-testhelpers';
+import { ensureBackofficeToken } from './auth-token';
 
 // ── Protected node IDs (NEVER delete these) ────────────────────────────────
 
@@ -16,52 +17,44 @@ const API_BASE = '/umbraco/management/api/v1/updoc/workflows';
 const TEST_WORKFLOW = 'tailoredTourPdf';
 
 async function apiGet(page: Page, path: string): Promise<any> {
-	return page.evaluate(async (apiPath) => {
-		const tokenJson = localStorage.getItem('umb:userAuthTokenResponse');
-		if (!tokenJson) throw new Error('No auth token in localStorage');
-		const { access_token } = JSON.parse(tokenJson);
+	const token = await ensureBackofficeToken(page);
+	return page.evaluate(async ({ apiPath, accessToken }) => {
 		const resp = await fetch(apiPath, {
 			headers: {
 				'Content-Type': 'application/json',
-				Authorization: `Bearer ${access_token}`,
+				Authorization: `Bearer ${accessToken}`,
 			},
 		});
 		if (!resp.ok) throw new Error(`API GET ${apiPath} failed: ${resp.status}`);
 		return resp.json();
-	}, path);
+	}, { apiPath: path, accessToken: token });
 }
 
 async function apiPutBody(page: Page, path: string, body?: any): Promise<void> {
 	await page.evaluate(
-		async ({ apiPath, apiBody }) => {
-			const tokenJson = localStorage.getItem('umb:userAuthTokenResponse');
-			if (!tokenJson) throw new Error('No auth token in localStorage');
-			const { access_token } = JSON.parse(tokenJson);
+		async ({ apiPath, apiBody, accessToken }) => {
 			const resp = await fetch(apiPath, {
 				method: 'PUT',
 				headers: {
 					'Content-Type': 'application/json',
-					Authorization: `Bearer ${access_token}`,
+					Authorization: `Bearer ${accessToken}`,
 				},
 				...(apiBody !== undefined ? { body: JSON.stringify(apiBody) } : {}),
 			});
 			if (!resp.ok) throw new Error(`API PUT ${apiPath} failed: ${resp.status}`);
 		},
-		{ apiPath: path, apiBody: body }
+		{ apiPath: path, apiBody: body, accessToken: await ensureBackofficeToken(page) }
 	);
 }
 
 async function apiPutJson(page: Page, path: string, body: any): Promise<any> {
 	return page.evaluate(
-		async ({ apiPath, apiBody }) => {
-			const tokenJson = localStorage.getItem('umb:userAuthTokenResponse');
-			if (!tokenJson) throw new Error('No auth token in localStorage');
-			const { access_token } = JSON.parse(tokenJson);
+		async ({ apiPath, apiBody, accessToken }) => {
 			const resp = await fetch(apiPath, {
 				method: 'PUT',
 				headers: {
 					'Content-Type': 'application/json',
-					Authorization: `Bearer ${access_token}`,
+					Authorization: `Bearer ${accessToken}`,
 				},
 				body: JSON.stringify(apiBody),
 			});
@@ -71,20 +64,18 @@ async function apiPutJson(page: Page, path: string, body: any): Promise<any> {
 			}
 			return resp.json().catch(() => null);
 		},
-		{ apiPath: path, apiBody: body }
+		{ apiPath: path, apiBody: body, accessToken: await ensureBackofficeToken(page) }
 	);
 }
 
 async function apiPost(page: Page, path: string): Promise<any> {
-	return page.evaluate(async (apiPath) => {
-		const tokenJson = localStorage.getItem('umb:userAuthTokenResponse');
-		if (!tokenJson) throw new Error('No auth token in localStorage');
-		const { access_token } = JSON.parse(tokenJson);
+	const token = await ensureBackofficeToken(page);
+	return page.evaluate(async ({ apiPath, accessToken }) => {
 		const resp = await fetch(apiPath, {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
-				Authorization: `Bearer ${access_token}`,
+				Authorization: `Bearer ${accessToken}`,
 			},
 		});
 		if (!resp.ok) {
@@ -92,7 +83,7 @@ async function apiPost(page: Page, path: string): Promise<any> {
 			throw new Error(`API POST ${apiPath} failed: ${resp.status} — ${text}`);
 		}
 		return resp.json().catch(() => null);
-	}, path);
+	}, { apiPath: path, accessToken: token });
 }
 
 // ── Sprint 1: contentTypeKey round-trip ─────────────────────────────────────

--- a/src/UpDoc/wwwroot/App_Plugins/UpDoc/tests/e2e/creating-a-workflow.screenshots.ts
+++ b/src/UpDoc/wwwroot/App_Plugins/UpDoc/tests/e2e/creating-a-workflow.screenshots.ts
@@ -19,6 +19,7 @@ import { expect, Page } from '@playwright/test';
 import { test } from '@umbraco/playwright-testhelpers';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { ensureBackofficeToken } from './auth-token';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -48,10 +49,7 @@ async function capture(page: Page, name: string) {
  * so screenshots are captured against a known starting state.
  */
 async function deleteWorkflowIfExists(page: Page, alias: string) {
-  const token = await page.evaluate(() => localStorage.getItem('umb:userAuthTokenResponse'));
-  if (!token) return;
-
-  const authToken = JSON.parse(token).access_token;
+  const authToken = await ensureBackofficeToken(page);
 
   try {
     await page.request.delete(

--- a/src/UpDoc/wwwroot/App_Plugins/UpDoc/tests/e2e/smoke-test-pdf.spec.ts
+++ b/src/UpDoc/wwwroot/App_Plugins/UpDoc/tests/e2e/smoke-test-pdf.spec.ts
@@ -1,5 +1,6 @@
 import { expect, Page } from '@playwright/test';
 import { ConstantHelper, test } from '@umbraco/playwright-testhelpers';
+import { ensureBackofficeToken } from './auth-token';
 
 /**
  * Generic smoke test for any PDF via environment variables.
@@ -62,35 +63,31 @@ async function selectPdf(page: Page, folderName: string, pdfName: string) {
 // ── API helpers ──────────────────────────────────────────────────────────────
 
 async function apiGet(page: Page, path: string): Promise<any> {
-	return page.evaluate(async (apiPath) => {
-		const tokenJson = localStorage.getItem('umb:userAuthTokenResponse');
-		if (!tokenJson) throw new Error('No auth token in localStorage');
-		const { access_token } = JSON.parse(tokenJson);
+	const token = await ensureBackofficeToken(page);
+	return page.evaluate(async ({ apiPath, accessToken }) => {
 		const resp = await fetch(apiPath, {
 			headers: {
 				'Content-Type': 'application/json',
-				Authorization: `Bearer ${access_token}`,
+				Authorization: `Bearer ${accessToken}`,
 			},
 		});
 		if (!resp.ok) throw new Error(`API GET ${apiPath} failed: ${resp.status}`);
 		return resp.json();
-	}, path);
+	}, { apiPath: path, accessToken: token });
 }
 
 async function apiPut(page: Page, path: string): Promise<void> {
-	await page.evaluate(async (apiPath) => {
-		const tokenJson = localStorage.getItem('umb:userAuthTokenResponse');
-		if (!tokenJson) throw new Error('No auth token in localStorage');
-		const { access_token } = JSON.parse(tokenJson);
+	const token = await ensureBackofficeToken(page);
+	await page.evaluate(async ({ apiPath, accessToken }) => {
 		const resp = await fetch(apiPath, {
 			method: 'PUT',
 			headers: {
 				'Content-Type': 'application/json',
-				Authorization: `Bearer ${access_token}`,
+				Authorization: `Bearer ${accessToken}`,
 			},
 		});
 		if (!resp.ok) throw new Error(`API PUT ${apiPath} failed: ${resp.status}`);
-	}, path);
+	}, { apiPath: path, accessToken: token });
 }
 
 // ── Value helpers ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Every API-based E2E test failed with `No auth token in localStorage`. 19 of 20 tests in `blockkey-reconciliation.spec.ts`; the only passing test was the one that never touched the API.

### Cause

The specs read the token out of web storage:

```js
const tokenJson = localStorage.getItem('umb:userAuthTokenResponse');
```

On Umbraco 17.5.3 that key does not exist. `HideBackOfficeTokensHandler` encrypts backoffice tokens into HTTP-only cookies by design, so scripts cannot read them.

Probes on a freshly restarted site, after a clean login with the backoffice fully booted:

- `localStorage` contains only `umb:appLanguage`, `sessionStorage` is empty
- live backoffice requests carry `Authorization: Bearer [redacted]`
- `fetch(..., { credentials: 'include' })` → **401**
- `page.request.get(...)` → **401**

The 401s are expected rather than a broken session. Cookies are the refresh credential; the Management API wants a bearer token in the header.

### Not a regression

| | UpDoc | Tailored Travel |
|---|---|---|
| Umbraco | 17.5.3 | 17.5.3 |
| `@umbraco/playwright-testhelpers` | 17.0.15 | 17.0.15 |
| Reads `umb:userAuthTokenResponse` | yes | never |
| API-based tests | yes | none, UI only |

Same versions on both sides, so the variable is controlled. Tailored Travel has no `.spec.ts` files and makes zero API calls, which is why it never hit this. An approach UpDoc took alone, not something that broke.

Also unrelated to the cookie rename in #107.

### Fix

Ask the backoffice's own auth context, which is what backoffice code does for authenticated calls. New `tests/e2e/auth-token.ts` raises a `umb:context-request` event for `UmbAuthContext` and calls `getLatestToken()`.

Two details verified against the Umbraco source rather than guessed:

- the event carries `contextAlias`/`apiAlias`/`callback` **directly on the event**, not in `detail`
- `apiAlias` is required and defaults to `'default'`

Getting either wrong makes the request hang silently, which is how the first attempt failed.

### Verification

`blockkey-reconciliation.spec.ts` **20/20 passed**, up from 1/20.

`smoke-test-pdf.spec.ts` and `creating-a-workflow.screenshots.ts` are migrated to the same helper but not run here: the smoke test creates and deletes content, and the screenshots spec rewrites committed PNGs. Both are better run deliberately.

Worth noting `creating-a-workflow.screenshots.ts` previously returned early when the token was missing, so its cleanup step had been silently skipped rather than failing.

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)
