### PR TITLE
Mark the mirror with a green header and its own login screen

### DIFF
--- a/src/TailoredTravel.Web/App_Plugins/MirrorBanner/mirror-banner.css
+++ b/src/TailoredTravel.Web/App_Plugins/MirrorBanner/mirror-banner.css
@@ -1,0 +1,79 @@
+/*
+ * Marks this install as the local mirror, not the live Tailored Travel site.
+ *
+ * The two look identical in a browser, and the only real difference is the port.
+ * Colouring the backoffice header removes the guesswork before you read anything.
+ *
+ * Umbraco's own positive green (#0d8844), so it sits with the rest of the UI
+ * rather than fighting it.
+ */
+
+:root {
+	--mirror-green: #0d8844;
+	--mirror-green-dark: #0a6b36;
+}
+
+/* The main backoffice header bar. */
+umb-backoffice-header,
+#header,
+.uui-text umb-backoffice-header {
+	background-color: var(--mirror-green) !important;
+}
+
+umb-backoffice-header::part(header),
+umb-backoffice-main > umb-backoffice-header {
+	background-color: var(--mirror-green) !important;
+}
+
+/*
+ * Umbraco builds the header from custom elements, so the background is set on a
+ * token rather than a class. Overriding the token catches it wherever it renders.
+ */
+:root,
+:host {
+	--uui-color-header-surface: var(--mirror-green) !important;
+	--uui-color-header-surface-emphasis: var(--mirror-green-dark) !important;
+}
+
+/* The login screen, which is where you first notice which site you are on. */
+umb-auth,
+umb-login,
+.uui-login,
+#login {
+	--uui-color-interactive: var(--mirror-green);
+}
+
+umb-auth::before,
+umb-login::before {
+	content: "LOCAL MIRROR — not the live site";
+	display: block;
+	background: var(--mirror-green);
+	color: #fff;
+	text-align: center;
+	padding: 0.5rem 1rem;
+	font-weight: 600;
+	letter-spacing: 0.02em;
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	z-index: 9999;
+}
+
+/*
+ * A permanent strip along the very top. Belt and braces: if the header selectors
+ * ever change in a future Umbraco version, this still shows.
+ */
+body::before {
+	content: "LOCAL MIRROR";
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	height: 4px;
+	background: var(--mirror-green);
+	color: transparent;
+	font-size: 0;
+	z-index: 2147483647;
+	pointer-events: none;
+}

--- a/src/TailoredTravel.Web/App_Plugins/MirrorBanner/mirror-banner.js
+++ b/src/TailoredTravel.Web/App_Plugins/MirrorBanner/mirror-banner.js
@@ -1,0 +1,26 @@
+/**
+ * Marks this install as the local mirror rather than the live Tailored Travel site.
+ *
+ * Registered as a `bundle` in umbraco-package.json, which Umbraco loads on every
+ * backoffice startup. A `theme` would have been the obvious choice, but themes are
+ * a per-user preference stored in localStorage and selected from the profile
+ * screen, so it would only apply once someone remembered to turn it on and would
+ * vanish if browser data were cleared. This always applies.
+ */
+
+const STYLESHEET_HREF = '/App_Plugins/MirrorBanner/mirror-banner.css';
+
+function injectStylesheet() {
+	if (document.querySelector(`link[href="${STYLESHEET_HREF}"]`)) return;
+
+	const link = document.createElement('link');
+	link.rel = 'stylesheet';
+	link.href = STYLESHEET_HREF;
+	document.head.appendChild(link);
+}
+
+injectStylesheet();
+
+export const onInit = () => {
+	injectStylesheet();
+};

--- a/src/TailoredTravel.Web/App_Plugins/MirrorBanner/umbraco-package.json
+++ b/src/TailoredTravel.Web/App_Plugins/MirrorBanner/umbraco-package.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../../umbraco-package-schema.json",
+  "id": "mirror-banner",
+  "name": "Mirror Banner",
+  "version": "1.0.0",
+  "extensions": [
+    {
+      "type": "bundle",
+      "alias": "TailoredTravelMirror.Banner",
+      "name": "Tailored Travel Mirror Banner",
+      "js": "/App_Plugins/MirrorBanner/mirror-banner.js"
+    }
+  ]
+}

--- a/src/TailoredTravel.Web/appsettings.Development.json
+++ b/src/TailoredTravel.Web/appsettings.Development.json
@@ -20,7 +20,8 @@
   "Umbraco": {
     "CMS": {
       "Content": {
-        "MacroErrors": "Throw"
+        "MacroErrors": "Throw",
+        "LoginBackgroundImage": "../assets/mirror-login.svg"
       },
       "Hosting": {
         "Debug": true

--- a/src/TailoredTravel.Web/wwwroot/assets/mirror-login.svg
+++ b/src/TailoredTravel.Web/wwwroot/assets/mirror-login.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 1200" preserveAspectRatio="xMidYMid slice" role="img" aria-label="UpDoc local mirror, not the live site">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0d8844"/>
+      <stop offset="1" stop-color="#0a5c2f"/>
+    </linearGradient>
+
+    <linearGradient id="root" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#f4913c"/>
+      <stop offset="1" stop-color="#e2701a"/>
+    </linearGradient>
+
+    <pattern id="stripes" width="56" height="56" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+      <rect width="56" height="56" fill="none"/>
+      <rect width="28" height="56" fill="#ffffff" opacity="0.03"/>
+    </pattern>
+  </defs>
+
+  <rect width="900" height="1200" fill="url(#bg)"/>
+  <rect width="900" height="1200" fill="url(#stripes)"/>
+
+  <!-- Carrot, tilted slightly so it does not sit too stiffly -->
+  <g transform="translate(450 400) rotate(-12)">
+    <path d="M0 -60
+             C 34 -60, 52 -34, 48 4
+             C 44 52, 22 128, 4 188
+             C 1 198, -1 198, -4 188
+             C -22 128, -44 52, -48 4
+             C -52 -34, -34 -60, 0 -60 Z"
+          fill="url(#root)"/>
+
+    <g stroke="#c25c12" stroke-width="3" stroke-linecap="round" opacity="0.45">
+      <path d="M-30 -18 L -14 -12" fill="none"/>
+      <path d="M14 -4 L 31 -12" fill="none"/>
+      <path d="M-26 34 L -10 40" fill="none"/>
+      <path d="M12 60 L 27 52" fill="none"/>
+      <path d="M-18 88 L -6 93" fill="none"/>
+      <path d="M8 118 L 18 111" fill="none"/>
+    </g>
+
+    <g fill="#2fae63">
+      <path d="M-6 -62 C -40 -96, -58 -140, -46 -178 C -18 -160, -6 -114, -2 -64 Z"/>
+      <path d="M2 -66 C 4 -118, 18 -166, 46 -186 C 54 -142, 32 -98, 8 -62 Z"/>
+      <path d="M-2 -64 C -6 -112, -2 -156, 2 -190 C 14 -152, 12 -108, 4 -62 Z" fill="#3cc472"/>
+    </g>
+  </g>
+
+  <!-- Stacked so nothing is lost when the panel crops horizontally -->
+  <g fill="#ffffff" text-anchor="middle" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+    <text x="450" y="760" font-size="104" font-weight="700" letter-spacing="6" opacity="0.96">LOCAL</text>
+    <text x="450" y="866" font-size="104" font-weight="700" letter-spacing="6" opacity="0.96">MIRROR</text>
+
+    <text x="450" y="946" font-size="34" font-weight="500" letter-spacing="2" opacity="0.8">What&#8217;s up, Doc?</text>
+    <text x="450" y="992" font-size="34" font-weight="500" letter-spacing="2" opacity="0.8">This is not the live site.</text>
+
+    <text x="450" y="1064" font-size="26" font-weight="400" letter-spacing="2" opacity="0.6">localhost:44351</text>
+  </g>
+</svg>


### PR DESCRIPTION
The mirror and the live Tailored Travel checkout are identical in a browser apart from the port number, so it is easy to edit one thinking it is the other. Two visual markers, neither of which can be forgotten to turn on.

## Green backoffice header

Registered as a **bundle**, not a theme.

Themes were the obvious choice, but the CMS source shows they are a per-user preference stored in `localStorage` and selected from the profile screen. A theme would only apply once someone remembered to turn it on, and would vanish if browser data were cleared. A bundle loads on every backoffice startup.

Uses Umbraco's own positive green (`#0d8844`) via the `--uui-color-header-surface` token, so it sits with the rest of the UI rather than fighting it. Orange would read better as a caution, but this is a header you look at all day.

Plain JS and CSS, no build step. It is safety scaffolding, not product code.

## Login screen

Uses Umbraco's `LoginBackgroundImage` setting rather than CSS, so it is supported configuration rather than a hack. `appsettings.Development.json` only.

Two things found by reading `BackOfficeGraphicsController`, both worth recording:

- **The image is served through an API endpoint**, not a direct path, and the controller prepends `/umbraco` to the configured value. So `assets/foo.svg` resolves to `wwwroot/umbraco/assets/foo.svg`, which is Umbraco's own folder and gets replaced on upgrade. `../assets/foo.svg` climbs back out to the web root, where a site's own assets belong.
- **The panel is portrait**, so a landscape viewBox gets cropped at the sides under `preserveAspectRatio="slice"`. The first attempt lost the L and R from "LOCAL MIRROR". Wording is now stacked rather than relying on the width being there.

SVG rather than a bitmap: a few KB, sharp at any size, readable in a diff. Carrot because UpDoc.

## Note for refreshes

The banner lives in the mirror's `App_Plugins`, so re-copying the site from the live checkout will remove it. Both it and the login SVG need re-adding after each refresh.

Refs #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)
