### PR TITLE
Ignore runtime-generated data protection keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -522,3 +522,7 @@ appsettings-schema.json
 
 # Git worktrees (docs worktree lives here)
 .worktrees/
+
+# Umbraco generates data protection keys at runtime. Machine-specific, and
+# regenerated automatically if absent, so they must never be committed.
+**/DataProtection-Keys/


### PR DESCRIPTION
Umbraco writes `DataProtection-Keys` at first startup. They are machine-specific and regenerated automatically if absent, so they should never be committed.

The mirror generated a fresh set when it first ran, which is what surfaced this. The originals were deliberately excluded when the mirror was copied, but nothing stopped the new ones being staged by accident.

Part of a tidy-up before the next release: stale branches pruned, line-ending noise discarded, and this rule added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)