### PR TITLE
Describe UpDoc's API in Swagger

### DIFF
--- a/src/UpDoc/Composers/UpDocComposer.cs
+++ b/src/UpDoc/Composers/UpDocComposer.cs
@@ -1,9 +1,12 @@
+using UpDoc.OpenApi;
 using UpDoc.Services;
 using UpDoc.NotificationHandlers;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Notifications;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace UpDoc.Composers;
 
@@ -24,5 +27,9 @@ public class UpDocComposer : IComposer
         builder.Services.AddScoped<IDestinationStructureService, DestinationStructureService>();
         builder.Services.AddSingleton<IContentTransformService, ContentTransformService>();
         builder.AddNotificationHandler<UmbracoApplicationStartedNotification, WorkflowMigrationHandler>();
+
+        // Describes UpDoc's API at /umbraco/swagger/updoc/swagger.json. The controllers
+        // already declare [MapToApi] but nothing created the document they name.
+        builder.Services.ConfigureOptions<ConfigureUpDocSwaggerGenOptions>();
     }
 }

--- a/src/UpDoc/Controllers/DocumentTypeController.cs
+++ b/src/UpDoc/Controllers/DocumentTypeController.cs
@@ -1,4 +1,5 @@
 using Asp.Versioning;
+using UpDoc.OpenApi;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Attributes;
@@ -11,7 +12,7 @@ namespace UpDoc.Controllers;
 [ApiController]
 [ApiVersion("1.0")]
 [Route("umbraco/management/api/v{version:apiVersion}/updoc/document-types")]
-[MapToApi("updoc")]
+[MapToApi(UpDocApiConfiguration.ApiName)]
 [Authorize(Policy = AuthorizationPolicies.BackOfficeAccess)]
 [JsonOptionsName("UmbracoManagementApi")]
 public class DocumentTypeController : ControllerBase

--- a/src/UpDoc/Controllers/PdfExtractionController.cs
+++ b/src/UpDoc/Controllers/PdfExtractionController.cs
@@ -1,4 +1,5 @@
 using Asp.Versioning;
+using UpDoc.OpenApi;
 using UpDoc.Models;
 using UpDoc.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -15,7 +16,7 @@ namespace UpDoc.Controllers;
 [ApiController]
 [ApiVersion("1.0")]
 [Route("umbraco/management/api/v{version:apiVersion}/updoc")]
-[MapToApi("updoc")]
+[MapToApi(UpDocApiConfiguration.ApiName)]
 [Authorize(Policy = AuthorizationPolicies.BackOfficeAccess)]
 [JsonOptionsName("UmbracoManagementApi")]
 public class PdfExtractionController : ControllerBase

--- a/src/UpDoc/Controllers/WorkflowController.cs
+++ b/src/UpDoc/Controllers/WorkflowController.cs
@@ -1,4 +1,5 @@
 using Asp.Versioning;
+using UpDoc.OpenApi;
 using UpDoc.Models;
 using UpDoc.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -15,7 +16,7 @@ namespace UpDoc.Controllers;
 [ApiController]
 [ApiVersion("1.0")]
 [Route("umbraco/management/api/v{version:apiVersion}/updoc/workflows")]
-[MapToApi("updoc")]
+[MapToApi(UpDocApiConfiguration.ApiName)]
 [Authorize(Policy = AuthorizationPolicies.BackOfficeAccess)]
 [JsonOptionsName("UmbracoManagementApi")]
 public class WorkflowController : ControllerBase

--- a/src/UpDoc/OpenApi/ConfigureUpDocSwaggerGenOptions.cs
+++ b/src/UpDoc/OpenApi/ConfigureUpDocSwaggerGenOptions.cs
@@ -1,0 +1,36 @@
+// SwaggerDoc is an extension method on SwaggerGenOptions declared in the
+// Microsoft.Extensions.DependencyInjection namespace, not in Swashbuckle's own.
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.OpenApi;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace UpDoc.OpenApi;
+
+/// <summary>
+/// Registers UpDoc's Swagger document.
+///
+/// UpDoc's controllers have always declared [MapToApi(UpDocApiConfiguration.ApiName)],
+/// but that attribute only says which document an endpoint belongs to — something still
+/// has to create the document. Without this, /umbraco/swagger/updoc/swagger.json returned
+/// 404 and UpDoc's API was invisible to anything reading Swagger, despite working
+/// perfectly well for the backoffice.
+///
+/// Follows the pattern Umbraco uses for its own separate APIs, e.g.
+/// ConfigureUmbracoDeliveryApiSwaggerGenOptions.
+/// </summary>
+public class ConfigureUpDocSwaggerGenOptions : IConfigureOptions<SwaggerGenOptions>
+{
+    public void Configure(SwaggerGenOptions swaggerGenOptions)
+        => swaggerGenOptions.SwaggerDoc(
+            UpDocApiConfiguration.ApiName,
+            new OpenApiInfo
+            {
+                Title = UpDocApiConfiguration.ApiTitle,
+                Version = "Latest",
+                Description =
+                    "Create Umbraco documents from external sources (PDF, web pages, markdown) "
+                    + "using configurable extraction workflows. "
+                    + $"You can find out more in [the documentation]({UpDocApiConfiguration.ApiDocumentationLink})."
+            });
+}

--- a/src/UpDoc/OpenApi/UpDocApiConfiguration.cs
+++ b/src/UpDoc/OpenApi/UpDocApiConfiguration.cs
@@ -1,0 +1,20 @@
+namespace UpDoc.OpenApi;
+
+/// <summary>
+/// Identifies UpDoc's API to Swagger and to the [MapToApi] attribute on its controllers.
+/// </summary>
+public static class UpDocApiConfiguration
+{
+    /// <summary>
+    /// The Swagger document name. Also the URL segment:
+    /// /umbraco/swagger/updoc/swagger.json.
+    ///
+    /// Changing this breaks any consumer pointed at the old path, so treat it as a
+    /// published contract rather than an internal name.
+    /// </summary>
+    public const string ApiName = "updoc";
+
+    public const string ApiTitle = "UpDoc API";
+
+    public const string ApiDocumentationLink = "https://umtemplates.github.io/UpDoc/";
+}


### PR DESCRIPTION
Closes #134. Unblocks #130.

UpDoc has had its own API all along. All three controllers declare `[MapToApi("updoc")]`, and the backoffice calls them constantly. But nothing created the document that attribute names, so `/umbraco/swagger/updoc/swagger.json` returned 404 and the API was invisible to anything reading Swagger.

Registered the way Umbraco registers its own separate APIs, following `ConfigureUmbracoDeliveryApiSwaggerGenOptions`.

## What appears now

35 endpoints: extraction, transformation, area detection, section rules, workflow config. Browsable and callable through Swagger UI, which is useful on its own for seeing what extraction returns without driving the dialog.

## Two things worth noting

**The API name is now a constant.** It was repeated as a string across three controllers. It is also the URL segment, so changing it breaks any consumer pointed at the old path — worth treating as a published contract.

**Namespaced `UpDoc.OpenApi`, not `UpDoc.Configuration`.** The latter shadowed AngleSharp's `Configuration` class inside `UpDoc.Services` and broke `HtmlExtractionService`'s `Configuration.Default` calls. `OpenApi` is more accurate anyway.

## Not a behaviour change

This is description, not new surface. The endpoints already existed and already worked.

Verified against the mirror: 404 before, 200 after, all 35 routes present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)