### PR TITLE
Stop reporting import facts as orphaned sources

### DIFF
--- a/src/UpDoc/Models/ImportFacts.cs
+++ b/src/UpDoc/Models/ImportFacts.cs
@@ -1,0 +1,26 @@
+namespace UpDoc.Models;
+
+/// <summary>
+/// Mapping sources that describe the import itself rather than content extracted
+/// from it — the file the editor picked, and in future the URL they typed.
+///
+/// These are not sections, so anything that resolves or validates a mapping source
+/// against extracted content has to skip them. The "$" prefix marks them as such.
+///
+/// Mirrors IMPORT_FACT_SOURCE_FILE in workflow.types.ts. The two must agree: the
+/// TypeScript side writes these into map.json, this side reads them back.
+/// </summary>
+public static class ImportFacts
+{
+    /// <summary>Marks a map.json source as an import fact rather than a section id.</summary>
+    public const string Prefix = "$";
+
+    /// <summary>The file picked for this import.</summary>
+    public const string SourceFile = "$sourceFile";
+
+    /// <summary>
+    /// Whether a map.json source describes the import rather than naming a section.
+    /// </summary>
+    public static bool IsImportFact(string? source) =>
+        source?.StartsWith(Prefix, StringComparison.Ordinal) == true;
+}

--- a/src/UpDoc/Services/WorkflowService.cs
+++ b/src/UpDoc/Services/WorkflowService.cs
@@ -281,8 +281,12 @@ public class WorkflowService : IWorkflowService
 
                 // Check source exists in this source config
                 // Skip when sections is empty — area-rules workflows produce sections
-                // dynamically via the transform pipeline, not statically in source.json
-                if (validSourceKeys.Count > 0 && !validSourceKeys.Contains(mapping.Source))
+                // dynamically via the transform pipeline, not statically in source.json.
+                // Import facts are skipped too: they describe the import rather than
+                // naming a section, so no source config will ever list them.
+                if (validSourceKeys.Count > 0
+                    && !ImportFacts.IsImportFact(mapping.Source)
+                    && !validSourceKeys.Contains(mapping.Source))
                 {
                     errors.Add($"WARN: map.json source '{mapping.Source}' not found in source-{sourceType}.json (will be skipped for this source type)");
                 }
@@ -365,6 +369,11 @@ public class WorkflowService : IWorkflowService
                     foreach (var mapping in config.Map.Mappings)
                     {
                         if (!mapping.Enabled) continue;
+
+                        // Import facts describe the import rather than naming a section,
+                        // so there is nothing in transform.json for them to match.
+                        if (ImportFacts.IsImportFact(mapping.Source)) continue;
+
                         if (!validSectionKeys.Contains(mapping.Source))
                         {
                             errors.Add($"WARN: source '{mapping.Source}' not found in transform.json (orphaned source)");
@@ -1698,6 +1707,10 @@ public class WorkflowService : IWorkflowService
                     foreach (var mapping in mapConfig.Mappings)
                     {
                         if (!string.IsNullOrEmpty(mapping.SourceKey)) continue;
+
+                        // Import facts have no section behind them, so there is no
+                        // stableKey to backfill.
+                        if (ImportFacts.IsImportFact(mapping.Source)) continue;
 
                         // Extract section ID from source (e.g., "features.content" → "features")
                         var dotIndex = mapping.Source.LastIndexOf('.');

--- a/src/UpDoc/wwwroot/App_Plugins/UpDoc/src/workflow.types.ts
+++ b/src/UpDoc/wwwroot/App_Plugins/UpDoc/src/workflow.types.ts
@@ -417,8 +417,19 @@ export type FillMechanism = 'sourceContent' | 'importFact';
  * Reserved map.json source key meaning "the file the editor picked for this import",
  * as opposed to content extracted from it. The "$" prefix marks it as an import fact
  * rather than a section id, so section resolution skips it.
+ *
+ * Mirrored in C# by ImportFacts (src/UpDoc/Models/ImportFacts.cs), which the server
+ * uses to skip these when validating and resolving sources. The two must agree.
  */
 export const IMPORT_FACT_SOURCE_FILE = '$sourceFile';
+
+/** Marks a map.json source as an import fact rather than a section id. */
+export const IMPORT_FACT_PREFIX = '$';
+
+/** Whether a map.json source describes the import rather than naming a section. */
+export function isImportFact(source: string): boolean {
+	return source.startsWith(IMPORT_FACT_PREFIX);
+}
 
 export type FieldType =
 	| 'text'


### PR DESCRIPTION
Every workflow that maps the source file reported a warning that was never true:

```
WARN: source '$sourceFile' not found in transform.json (orphaned source)
```

Validation checks each mapping source against the sections in `transform.json`, and an import fact is not a section — it describes the import rather than naming content within it. Introduced by #124, and surfaced by the new `list-workflows` MCP tool from #130, which reports validation warnings in its output.

## Three places, not one

All assumed a mapping source is always a section id:

- `transform.json` validation — the warning above
- `source-{type}.json` validation — would warn the same way
- stableKey backfill — split `"$sourceFile"` on `.` and looked for a section by that name. Harmless, but pointless work on every run.

## The prefix now exists in C#

It only existed in TypeScript, so the server had no way to recognise one without matching a literal. `ImportFacts` gives it a definition on both sides, with a note that the two must agree — one writes these into `map.json`, the other reads them back.

## Verified

Against the mirror, before and after, through the MCP tool:

```
before: ["WARN: ... 'extras-to-your-tour.summary' ...", "WARN: ... '$sourceFile' ..."]
after:  ["WARN: ... 'extras-to-your-tour.summary' ..."]
```

The remaining warning is genuine — a mapping pointing at a section that is no longer in that workflow's transform. Left alone here; worth deciding separately whether the mapping is stale or the section went missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)