### PR TITLE
Wrap list-workflows' output in an object

### DIFF
--- a/mcp/src/umbraco-api/tools/workflows/get/list-workflows.ts
+++ b/mcp/src/umbraco-api/tools/workflows/get/list-workflows.ts
@@ -57,11 +57,20 @@ const workflowSummary = getUmbracoManagementApiV1UpdocWorkflowsResponseItem.desc
     ),
 });
 
-// A bare array, matching what the endpoint returns. It was declared as
-// { items: [...] } when the schema was hand-written, which the CLI never
-// caught because it does not validate output - only calling the tool over MCP
-// surfaced the mismatch.
-const outputSchema = z.array(workflowSummary);
+// An object wrapping the array, not a bare array.
+//
+// The endpoint returns a bare array, and declaring the schema that way looks
+// like the honest thing to do. It is not: the SDK's decorators assume an object
+// output schema throughout - withCursorPagination reaches for .extend() to add
+// nextCursor, and z.array() has no .extend - which surfaces at call time as
+// "Cannot read properties of undefined (reading '_zod')".
+//
+// So the tool wraps the response instead, and the handler below does the
+// wrapping. Both mistakes here were only ever visible through a real MCP client;
+// the CLI does not validate tool output and calls the handler directly.
+const outputSchema = z.object({
+  items: z.array(workflowSummary).describe("The workflows configured on this site"),
+});
 
 const listWorkflowsTool: ToolDefinition<typeof inputSchema, typeof outputSchema> = {
   name: "list-workflows",
@@ -77,12 +86,24 @@ const listWorkflowsTool: ToolDefinition<typeof inputSchema, typeof outputSchema>
     readOnlyHint: true,
   },
   handler: async () => {
-    return executeGetApiCall<
+    const result = await executeGetApiCall<
       ReturnType<UpDocApiClient["getUmbracoManagementApiV1UpdocWorkflows"]>,
       UpDocApiClient
     >((client) =>
       client.getUmbracoManagementApiV1UpdocWorkflows(CAPTURE_RAW_HTTP_RESPONSE),
     );
+
+    // The endpoint returns a bare array; the schema above declares an object.
+    // Wrapping here keeps the two in step. Left untouched on an error result,
+    // which has no structuredContent to wrap.
+    if (Array.isArray(result.structuredContent)) {
+      return {
+        ...result,
+        structuredContent: { items: result.structuredContent },
+      };
+    }
+
+    return result;
   },
 };
 


### PR DESCRIPTION
Reported from Tailored Travel: calling `list-workflows` through an MCP client returns

```
Cannot read properties of undefined (reading '_zod')
```

## Cause

Yesterday's fix caused it. The endpoint returns a bare array, so the output schema was changed to `z.array()` to match — which resolved the validation error and introduced this one.

The SDK's decorators assume an **object** output schema throughout. `withCursorPagination` reaches for `.extend()` to add `nextCursor`, `z.array()` has no `.extend`, so the schema handed to `registerTool` ends up `undefined` and the MCP SDK reads `._zod` off it.

## Fix

The schema declares `{ items: [...] }` and the handler wraps the response, rather than the schema bending to the API's shape.

## Two bugs in two days, on the same six lines

Both were invisible to the CLI, for different reasons:

- It does not validate tool output, so the first bug printed fine
- It calls the handler directly, bypassing `registerTool` entirely, so the second never occurred

Neither would have shipped if the tool had been exercised through an MCP client once. Worth remembering: `--call` proves the API call works and nothing about the tool contract.

## Verified

Through a real MCP client against the Tailored Travel site — both workflows returned, `isComplete: true`.

Reported by Tailored Travel's session, which ruled out auth, the network, a stale build and site health first, and correctly picked out the zero-parameter tool as the odd one among the two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)