### PR TITLE
Prepare the MCP server for npm

### DIFF
--- a/mcp/CLAUDE.md
+++ b/mcp/CLAUDE.md
@@ -2,9 +2,23 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with the MCP server template.
 
-## Template Overview
+## Overview
 
-Starter kit for creating new Umbraco MCP server projects. Copy this folder to start a new project. Not published to npm.
+UpDoc's MCP server, published to npm as `@umtemplates/updoc-mcp`. It exposes UpDoc's
+workflows and its create-from-source endpoint as tools, so an AI assistant can run an
+import without driving the backoffice.
+
+Scaffolded from `@umbraco-cms/create-umbraco-mcp-server`, so much of the structure
+below is the template's rather than ours.
+
+**It is published, so the tool contract is a promise.** Renaming a tool, removing one,
+or changing its arguments breaks anyone who has pinned a version. Versioning is semver
+and independent of UpDoc's NuGet version: patch for a fix, minor for a new tool, major
+for anything that breaks a caller.
+
+The published package contains `dist/` only. Its runtime dependencies are the five in
+`dependencies` — everything supporting the Cloudflare Worker and the eval tests is a
+devDependency, so consumers do not install it.
 
 ## Commands
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -76,6 +76,8 @@ Returns the new document's id, the workflow used, and how many values the mappin
 
 ## Notes
 
+This is an early release, and it depends on `@umbraco-cms/mcp-server-sdk`, which is currently in beta. Pin a version rather than tracking the latest if that matters to you.
+
 Only PDF sources are supported today. Markdown and web sources still go through the backoffice.
 
 `mappedValueCount` is worth checking against the workflow's `mappingCount` from `list-workflows`. A lower number means some mappings did not resolve, and the document is worth a look before publishing.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,161 +1,91 @@
-# mcp
+# @umtemplates/updoc-mcp
 
-MCP server template for Umbraco add-ons using the @umbraco-cms/mcp-server-sdk.
+An MCP server for [UpDoc](https://github.com/UmTemplates/UpDoc), letting an AI assistant create Umbraco documents from PDFs.
 
-## Getting Started
+UpDoc extracts content from a source document and maps it into a document blueprint using a configured workflow. This server exposes that as tools, so an assistant can run an import without driving the backoffice.
 
-### 1. Install Dependencies
+## Requirements
 
-```bash
-npm install
+- **Umbraco 17** with [Umbraco.Community.UpDoc](https://www.nuget.org/packages/Umbraco.Community.UpDoc) **17.5.3.6 or later** installed
+- At least one UpDoc workflow configured on the site
+- An Umbraco API user the server can authenticate as
+- Node 22 or later
+
+The version matters: the endpoint these tools call was added in 17.5.3.6.
+
+## Setup
+
+### 1. Create an API user
+
+In the Umbraco backoffice, go to **Users**, create an API user, and give it permission to read and create content. Note its client ID and secret.
+
+### 2. Register the server
+
+Add it to your MCP client's configuration. For Claude Code, that is `.mcp.json` in your project:
+
+```json
+{
+  "mcpServers": {
+    "updoc": {
+      "command": "npx",
+      "args": ["-y", "@umtemplates/updoc-mcp"],
+      "env": {
+        "UMBRACO_BASE_URL": "https://your-site.com",
+        "UMBRACO_CLIENT_ID": "your-api-user-client-id",
+        "UMBRACO_CLIENT_SECRET": "your-api-user-secret"
+      }
+    }
+  }
+}
 ```
 
-### 2. Configure Environment
+Running against a local site with a self-signed certificate? Add `"NODE_TLS_REJECT_UNAUTHORIZED": "0"` to `env`. Never do that against a production site.
 
-Copy `.env.example` to `.env` and fill in your Umbraco connection details:
+Keep this file out of version control — it holds a secret.
 
-```bash
-cp .env.example .env
-```
+### 3. Restart your MCP client
 
-### 3. Generate API Client (Optional)
+Servers connect at startup, so the tools will not appear until you restart.
 
-If you have an OpenAPI spec for your add-on:
+## Tools
 
-1. Update `orval.config.ts` to point to your spec
-2. Run the generator:
+### `list-workflows`
 
-```bash
-npm run generate
-```
+Lists the workflows configured on the site: which document type and blueprint each produces, which source types it accepts, and whether it is complete.
 
-### 4. Build and Test
+Start here. Other tools need the blueprint id, and this is where you find it.
 
-```bash
-# Build the server
-npm run build
+### `create-from-source`
 
-# Run tests
-npm test
+Creates a document from a PDF already in the media library.
 
-# Test with MCP Inspector
-npm run inspect
-```
+| Argument | Description |
+|----------|-------------|
+| `parentId` | Document to create under |
+| `documentTypeId` | The document type to create |
+| `blueprintId` | The blueprint to build from — also selects the workflow |
+| `mediaId` | The PDF in the media library |
+| `documentName` | Name for the new document |
+| `sourceType` | Optional; defaults to the workflow's own |
 
-## Project Structure
+Returns the new document's id, the workflow used, and how many values the mappings wrote.
 
-```
-├── src/
-│   ├── api/
-│   │   ├── client.ts           # API client configuration
-│   │   └── generated/          # Orval-generated API code
-│   ├── tools/
-│   │   └── example/            # Example tool collection
-│   │       ├── get/
-│   │       ├── post/
-│   │       └── index.ts
-│   └── index.ts                # Server entry point
-├── scripts/
-│   └── tunnels.sh              # Cloudflare tunnels for remote MCP client testing
-├── umbraco/
-│   ├── McpOAuthComposer.cs                            # Self-hosted: OAuth client for your own Worker
-│   ├── McpHostedClientsComposer.Cloud.cs              # Cloud only (commented out): one or more hosted MCP clients (Editor / Dev / …) chosen via array
-│   └── McpExternalLoginShortCircuitComposer.Cloud.cs  # Cloud only (commented out): redirects to Umbraco SSO instead of dead-ending at /umbraco/login
-├── __tests__/
-│   └── example/                # Example tests
-├── package.json
-├── tsconfig.json
-├── tsup.config.ts
-├── jest.config.ts
-├── orval.config.ts
-└── .env.example
-```
+**The document is created as a draft.** Review it, then publish separately.
 
-## Adding Your Own Tools
+**The PDF must already be uploaded.** This creates documents, it does not upload files — use Umbraco's own MCP server for that.
 
-1. Create a new folder under `src/tools/` for your tool collection
-2. Create tool files following the example pattern:
-   - `get/` for GET operations
-   - `post/` for POST operations
-   - `put/` for PUT operations
-   - `delete/` for DELETE operations
-3. Create an `index.ts` that exports the collection
-4. Register the collection in `src/index.ts`
+## Notes
 
-### Tool Pattern Example
+Only PDF sources are supported today. Markdown and web sources still go through the backoffice.
 
-```typescript
-import { z } from "zod";
-import {
-  withStandardDecorators,
-  executeGetApiCall,
-  CAPTURE_RAW_HTTP_RESPONSE,
-  ToolDefinition,
-} from "@umbraco-cms/mcp-server-sdk";
+`mappedValueCount` is worth checking against the workflow's `mappingCount` from `list-workflows`. A lower number means some mappings did not resolve, and the document is worth a look before publishing.
 
-const inputSchema = {
-  id: z.string().uuid(),
-};
+## Documentation
 
-const myTool: ToolDefinition<typeof inputSchema> = {
-  name: "my-tool",
-  description: "Does something useful",
-  inputSchema,
-  slices: ["read"],
-  annotations: { readOnlyHint: true },
-  handler: async ({ id }) => {
-    return executeGetApiCall((client) =>
-      client.getMyItem(id, CAPTURE_RAW_HTTP_RESPONSE)
-    );
-  },
-};
+- [UpDoc documentation](https://umtemplates.github.io/UpDoc/)
+- [How and why this was built](https://umtemplates.github.io/UpDoc/article-mcp-server/)
+- [Source and issues](https://github.com/UmTemplates/UpDoc)
 
-export default withStandardDecorators(myTool);
-```
-
-## Testing
-
-Tests use Jest with the MCP toolkit's testing helpers:
-
-```typescript
-import {
-  setupTestEnvironment,
-  createSnapshotResult,
-  createMockRequestHandlerExtra,
-} from "@umbraco-cms/mcp-server-sdk/testing";
-
-describe("my-tool", () => {
-  setupTestEnvironment();
-
-  it("should do something", async () => {
-    const result = await myTool.handler({ id: "..." }, createMockRequestHandlerExtra());
-    expect(createSnapshotResult(result)).toMatchSnapshot();
-  });
-});
-```
-
-## Testing with Claude Code
-
-This project ships with a `.mcp.json` that registers the MCP server with Claude Code automatically. Once you have run `init`, `discover`, and `npm run build`, open the project directory in Claude Code and the server is available immediately — no manual `claude mcp add` required.
-
-```bash
-# One-time setup
-npx @umbraco-cms/create-umbraco-mcp-server init   # writes credentials to .env
-npx @umbraco-cms/create-umbraco-mcp-server discover # generates API client
-npm run build                                       # compiles dist/index.js
-
-# Open in Claude Code — .mcp.json is picked up automatically
-claude .
-```
-
-The server reads credentials from `.env` via `node --env-file=.env ./dist/index.js`, so no secrets are committed to source control.
-
-## Publishing
-
-1. Update `package.json` with your package name and details
-2. Build: `npm run build`
-3. Publish: `npm publish`
-
-## License
+## Licence
 
 MIT

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -37,30 +37,44 @@
     "dist"
   ],
   "keywords": [
-    "Umbraco",
-    "MCP",
-    "Model Context Protocol"
+    "umbraco",
+    "umbraco-marketplace",
+    "mcp",
+    "model-context-protocol",
+    "pdf",
+    "content-import",
+    "ai"
   ],
-  "author": "",
+  "author": "Dean Leigh",
   "license": "MIT",
+  "homepage": "https://umtemplates.github.io/UpDoc/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/UmTemplates/UpDoc.git",
+    "directory": "mcp"
+  },
+  "bugs": {
+    "url": "https://github.com/UmTemplates/UpDoc/issues"
+  },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.191",
-    "@cloudflare/workers-oauth-provider": "^0.8.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@umbraco-cms/mcp-hosted": "1.0.0-beta.35",
     "@umbraco-cms/mcp-server-sdk": "1.0.0-beta.35",
-    "agents": "^0.6.0",
     "dotenv": "^17.4.2",
     "uuid": "^11.1.0",
     "yargs": "^18.0.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.191",
+    "@cloudflare/workers-oauth-provider": "^0.8.1",
     "@jest/types": "^29.6.3",
+    "@playwright/test": "^1.61.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^26.1.2",
     "@types/uuid": "^10.0.0",
     "@types/yargs": "^17.0.33",
+    "@umbraco-cms/mcp-hosted": "1.0.0-beta.35",
+    "agents": "^0.6.0",
     "jest": "^30.4.2",
     "msw": "^2.14.6",
     "orval": "^8.19.0",
@@ -68,9 +82,8 @@
     "ts-jest": "^29.4.11",
     "ts-node": "^10.9.2",
     "tsup": "^8.4.0",
-    "undici": "^8.9.0",
-    "@playwright/test": "^1.61.1",
     "typescript": "^5.8.3",
+    "undici": "^8.9.0",
     "wrangler": "^4.104.0"
   }
 }

--- a/mcp/src/config/mcp-servers.ts
+++ b/mcp/src/config/mcp-servers.ts
@@ -65,15 +65,23 @@ const realCmsServer: McpServerConfig = {
  * 3. Receive the same filter configuration (tools, slices, modes) as this server
  */
 export const mcpServers: McpServerConfig[] = [
-  // Use mock server for testing, real server otherwise
-  useMockChain ? mockCmsServer : realCmsServer,
-
-  // Add more chained MCP servers here as needed
-  // {
-  //   name: "another-mcp",
-  //   command: "npx",
-  //   args: ["-y", "@scope/another-mcp"],
-  //   env: { ... },
-  //   proxyTools: true,
-  // },
+  // Chaining to Umbraco's own MCP server is OFF by default, and deliberately so.
+  //
+  // The scaffold enables it, which spawns `npx -y @umbraco-cms/mcp-dev` at
+  // startup and proxies its ~350 tools through this server. Three problems for a
+  // published package:
+  //
+  //   1. The first run of a fresh install hangs, silently, while npx downloads
+  //      mcp-dev. Locally it looks instant only because the package is cached.
+  //   2. ~350 tools nobody asked for appear in the consumer's tool list.
+  //   3. Anyone already running Umbraco's server sees every tool twice, and has
+  //      to guess which to call.
+  //
+  // UpDoc's own tools do not delegate to it - they call UpDoc's endpoints. So
+  // the chain earns nothing here and costs all three.
+  //
+  // Set UMBRACO_MCP_CHAIN=true to turn it back on.
+  ...(process.env.UMBRACO_MCP_CHAIN === "true"
+    ? [useMockChain ? mockCmsServer : realCmsServer]
+    : []),
 ];


### PR DESCRIPTION
Everything the package needed before a first publish. npm versions cannot be replaced, only superseded, so this was worth doing carefully.

Each problem was found by **installing the packed tarball into an empty directory and running it as a consumer would** — not by reading the manifest. None of them were visible from the source tree.

## Chaining off by default

The scaffold enables it, which spawns `npx -y @umbraco-cms/mcp-dev` at startup and proxies ~350 tools through this server.

- A fresh install **hangs silently** on first run while npx downloads mcp-dev. Locally it looks instant only because the package is cached.
- ~350 tools nobody asked for appear in the consumer's list.
- Anyone already running Umbraco's own server sees every tool **twice** — reported from Tailored Travel.

UpDoc's tools call UpDoc's endpoints and never delegate, so the chain earned nothing. `UMBRACO_MCP_CHAIN=true` restores it.

## yargs is a runtime dependency

It was moved to devDependencies on the evidence that nothing in the bundle imports it. That evidence was wrong: the SDK loads it **dynamically** to parse `--call` and `--list-tools`.

Without it, both flags are silently ignored and the server just starts — no error, no output. A static grep could not have caught this; only running the installed package did.

## Four dependencies moved to devDependencies

The Cloudflare Worker and eval-test packages, none of which ship in `dist/`. A clean install is now **40 packages, 0 vulnerabilities**.

## README rewritten

It was the scaffold's, titled `# mcp`, explaining how to build a template. It is the npm front page, so it now covers what the server is, what it needs (Umbraco 17, UpDoc 17.5.3.6+, an API user), how to register it, and what the two tools do — including that documents are created as drafts.

## Metadata

`author`, `repository`, `homepage`, `bugs`. Without `repository` there is no link from npm back to the source.

Also notes the beta SDK dependency, since consumers inherit it.

## Verified

Clean install in an empty directory: 40 packages, 0 vulnerabilities, both tools listed, `list-workflows` returns the expected `{ items: [...] }` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)