### PR TITLE
Explain in the README how to run alongside Umbraco's server

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -74,6 +74,23 @@ Returns the new document's id, the workflow used, and how many values the mappin
 
 **The PDF must already be uploaded.** This creates documents, it does not upload files — use Umbraco's own MCP server for that.
 
+## Working alongside Umbraco's own MCP server
+
+This server provides UpDoc's tools only. For everything else — uploading media, reading a document back, publishing — register [`@umbraco-cms/mcp-dev`](https://www.npmjs.com/package/@umbraco-cms/mcp-dev) as a second server:
+
+```json
+{
+  "mcpServers": {
+    "umbraco": { "command": "npx", "args": ["-y", "@umbraco-cms/mcp-dev"], "env": { } },
+    "updoc":   { "command": "npx", "args": ["-y", "@umtemplates/updoc-mcp"], "env": { } }
+  }
+}
+```
+
+A typical import is two calls: upload the PDF with Umbraco's `create-media`, then pass the media id to `create-from-source`.
+
+This server *can* chain to Umbraco's and proxy its tools, but that is off by default. Chaining spawns a second server at startup, which makes the first run on a clean machine hang while npm fetches it, and it re-exposes around 350 tools that appear twice for anyone already running Umbraco's server directly. Set `UMBRACO_MCP_CHAIN=true` if you want it.
+
 ## Notes
 
 This is an early release, and it depends on `@umbraco-cms/mcp-server-sdk`, which is currently in beta. Pin a version rather than tracking the latest if that matters to you.


### PR DESCRIPTION
The README told people to use Umbraco's own MCP server for uploads without saying it has to be registered separately. Someone installing this could reasonably expect Umbraco's tools to come with it — the scaffold's default behaviour would have provided them, and we turned that off before publishing.

Adds a config example showing both servers registered side by side, notes that a typical import is two calls, and explains that chaining exists but is off by default with the reasons.

Does not reach npm until a republish, since `0.1.0` is immutable. It goes out with the next version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)